### PR TITLE
Load crypt keys from SphereCrypt.ini

### DIFF
--- a/Common/ccrypt.cpp
+++ b/Common/ccrypt.cpp
@@ -12,6 +12,7 @@
 #include "graycom.h"
 #include "graymul.h"
 #include "grayproto.h"
+#include "ccryptkeys.h"
 #endif
 
 const WORD Packet_Lengths_20000[XCMD_QTY] =	// from client 2.0.0 @offset 010e700
@@ -456,49 +457,23 @@ int CCryptBase::WriteClientVersion( TCHAR * pszVersion )
 
 bool CCryptBase::SetClientVersion( int iVer )
 {
-	m_fInit = false;
-	if ( iVer <= 0 )
-	{
-		m_MasterHi = 0;
-		m_MasterLo = 0;
-		m_iClientVersion = 0;
-		return true;
-	}
+        m_fInit = false;
+        if ( iVer <= 0 )
+        {
+                m_MasterHi = 0;
+                m_MasterLo = 0;
+                m_iClientVersion = 0;
+                return true;
+        }
 
-	struct CLIENTVER
-	{
-		int m_iVer;
-		UINT m_MasterHi;
-		UINT m_MasterLo;
-	};
-
-	static const CLIENTVER sm_ClientKeys[] =
-	{
-		{ 20000, CLIKEY_20000_HI, CLIKEY_20000_LO },
-		{ 12604, CLIKEY_12604_HI, CLIKEY_12604_LO },
-		{ 12603, CLIKEY_12603_HI, CLIKEY_12603_LO },
-		{ 12602, CLIKEY_12602_HI, CLIKEY_12602_LO },
-		{ 12601, CLIKEY_12601_HI, CLIKEY_12601_LO },
-		{ 12600, CLIKEY_12600_HI, CLIKEY_12600_LO },
-		{ 12537, CLIKEY_12537_HI, CLIKEY_12537_LO },
-		{ 12536, CLIKEY_12536_HI1, CLIKEY_12536_LO1 },
-		{ 12535, CLIKEY_12535_HI, CLIKEY_12535_LO },
-		{ 12534, CLIKEY_12534_HI, CLIKEY_12534_LO },
-		{ 12533, CLIKEY_12533_HI, CLIKEY_12533_LO },
-		{ 12532, CLIKEY_12532_HI, CLIKEY_12532_LO },
-		{ 12531, CLIKEY_12531_HI, CLIKEY_12531_LO },
-	};
-
-	for ( size_t i = 0; i < COUNTOF(sm_ClientKeys); ++i )
-	{
-		if ( sm_ClientKeys[i].m_iVer == iVer )
-		{
-			m_MasterHi = sm_ClientKeys[i].m_MasterHi;
-			m_MasterLo = sm_ClientKeys[i].m_MasterLo;
-			m_iClientVersion = iVer;
-			return true;
-		}
-	}
+        CCryptClientKey key;
+        if ( CCryptKeysManager::GetInstance().FindKeyForVersion( static_cast<DWORD>(iVer), key ))
+        {
+                m_MasterHi = key.m_MasterHi;
+                m_MasterLo = key.m_MasterLo;
+                m_iClientVersion = static_cast<int>( key.m_uiClientVersion );
+                return true;
+        }
 
         DEBUG_WARN(( "Unsupported ClientVersion %i, disabling encryption.\n", iVer ));
         m_MasterHi = 0;

--- a/Common/ccryptkeys.cpp
+++ b/Common/ccryptkeys.cpp
@@ -1,0 +1,196 @@
+#include "graycom.h"
+#include "grayproto.h"
+#include "ccryptkeys.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+
+namespace
+{
+        struct DefaultKeyEntry
+        {
+                DWORD m_uiClientVersion;
+                DWORD m_MasterHi;
+                DWORD m_MasterLo;
+        };
+
+        const DefaultKeyEntry k_DefaultKeys[] =
+        {
+                { 20000, CLIKEY_20000_HI, CLIKEY_20000_LO },
+                { 12604, CLIKEY_12604_HI, CLIKEY_12604_LO },
+                { 12603, CLIKEY_12603_HI, CLIKEY_12603_LO },
+                { 12602, CLIKEY_12602_HI, CLIKEY_12602_LO },
+                { 12601, CLIKEY_12601_HI, CLIKEY_12601_LO },
+                { 12600, CLIKEY_12600_HI, CLIKEY_12600_LO },
+                { 12537, CLIKEY_12537_HI, CLIKEY_12537_LO },
+                { 12536, CLIKEY_12536_HI1, CLIKEY_12536_LO1 },
+                { 12535, CLIKEY_12535_HI, CLIKEY_12535_LO },
+                { 12534, CLIKEY_12534_HI, CLIKEY_12534_LO },
+                { 12533, CLIKEY_12533_HI, CLIKEY_12533_LO },
+                { 12532, CLIKEY_12532_HI, CLIKEY_12532_LO },
+                { 12531, CLIKEY_12531_HI, CLIKEY_12531_LO },
+        };
+}
+
+CCryptKeysManager & CCryptKeysManager::GetInstance()
+{
+        static CCryptKeysManager s_Instance;
+        return s_Instance;
+}
+
+CCryptKeysManager::CCryptKeysManager()
+{
+        LoadDefaults();
+}
+
+void CCryptKeysManager::LoadDefaults()
+{
+        m_clientKeys.RemoveAll();
+        AddNoCryptKey();
+        for ( size_t i = 0; i < COUNTOF(k_DefaultKeys); ++i )
+        {
+                CCryptClientKey key;
+                key.m_uiClientVersion = k_DefaultKeys[i].m_uiClientVersion;
+                key.m_MasterHi = k_DefaultKeys[i].m_MasterHi;
+                key.m_MasterLo = k_DefaultKeys[i].m_MasterLo;
+                key.m_EncType = CRYPT_LOGIN;
+                AddKey(key);
+        }
+}
+
+void CCryptKeysManager::ResetToDefaults()
+{
+        LoadDefaults();
+}
+
+void CCryptKeysManager::AddNoCryptKey()
+{
+        CCryptClientKey key;
+        key.m_uiClientVersion = 0;
+        key.m_MasterHi = 0;
+        key.m_MasterLo = 0;
+        key.m_EncType = CRYPT_NONE;
+        m_clientKeys.Add(key);
+}
+
+void CCryptKeysManager::AddKey(const CCryptClientKey & key)
+{
+        for ( int i = 0; i < m_clientKeys.GetCount(); ++i )
+        {
+                if ( m_clientKeys[i].m_uiClientVersion == key.m_uiClientVersion )
+                {
+                        m_clientKeys.ElementAt(i) = key;
+                        return;
+                }
+        }
+        m_clientKeys.Add(key);
+}
+
+bool CCryptKeysManager::FindKeyForVersion(DWORD uiVersion, CCryptClientKey & outKey) const
+{
+        for ( int i = 0; i < m_clientKeys.GetCount(); ++i )
+        {
+                const CCryptClientKey & key = m_clientKeys.ElementAt(i);
+                if ( key.m_uiClientVersion == uiVersion )
+                {
+                        outKey = key;
+                        return true;
+                }
+        }
+        return false;
+}
+
+const CCryptClientKey * CCryptKeysManager::GetKey(size_t index) const
+{
+        if ( index >= (size_t)m_clientKeys.GetCount() )
+                return NULL;
+        return &m_clientKeys.ElementAt(static_cast<int>(index));
+}
+
+size_t CCryptKeysManager::GetKeyCount() const
+{
+        return static_cast<size_t>(m_clientKeys.GetCount());
+}
+
+CRYPT_TYPE CCryptKeysManager::ParseEncryptionType(const TCHAR * pszName) const
+{
+        if ( pszName == NULL || pszName[0] == '\0' )
+                return CRYPT_NONE;
+
+        if ( isdigit(static_cast<unsigned char>(pszName[0])) )
+        {
+                long iVal = strtol(pszName, NULL, 0);
+                if ( iVal < 0 )
+                        return CRYPT_NONE;
+                if ( iVal >= CRYPT_QTY )
+                        return CRYPT_NONE;
+                return static_cast<CRYPT_TYPE>(iVal);
+        }
+
+        if ( !strcmpi(pszName, "ENC_NONE") )
+                return CRYPT_NONE;
+        if ( !strcmpi(pszName, "ENC_BFISH") )
+                return CRYPT_BFISH;
+        if ( !strcmpi(pszName, "ENC_BTFISH") )
+                return CRYPT_BTFISH;
+        if ( !strcmpi(pszName, "ENC_TFISH") )
+                return CRYPT_TFISH;
+        if ( !strcmpi(pszName, "ENC_LOGIN") )
+                return CRYPT_LOGIN;
+
+        return CRYPT_NONE;
+}
+
+bool CCryptKeysManager::LoadKeyTable(CScript & script)
+{
+        bool fLoadedAny = false;
+
+        m_clientKeys.RemoveAll();
+        AddNoCryptKey();
+
+        while ( script.FindNextSection())
+        {
+                if ( script.IsSectionType("SPHERECRYPT") )
+                {
+                        while ( script.ReadKeyParse())
+                        {
+                                if ( ! script.HasArgs())
+                                        continue;
+
+                                const TCHAR * pszVersion = script.GetKey();
+                                if ( pszVersion == NULL || pszVersion[0] == '\0' )
+                                        continue;
+
+                                long iVersion = strtol(pszVersion, NULL, 10);
+                                if ( iVersion <= 0 )
+                                        continue;
+
+                                TCHAR * pszArgs = script.GetArgStr();
+                                if ( pszArgs == NULL || pszArgs[0] == '\0' )
+                                        continue;
+
+                                TCHAR * ppArgs[4];
+                                int iArgCount = ParseCmds( pszArgs, ppArgs, COUNTOF(ppArgs) );
+                                if ( iArgCount < 2 )
+                                        continue;
+
+                                CCryptClientKey key;
+                                key.m_uiClientVersion = static_cast<DWORD>(iVersion);
+                                key.m_MasterHi = strtoul( ppArgs[0], NULL, 16 );
+                                key.m_MasterLo = strtoul( ppArgs[1], NULL, 16 );
+                                key.m_EncType = ( iArgCount >= 3 ) ? ParseEncryptionType( ppArgs[2] ) : CRYPT_LOGIN;
+
+                                AddKey( key );
+                                fLoadedAny = true;
+                        }
+                }
+        }
+
+        if ( !fLoadedAny )
+        {
+                LoadDefaults();
+                return false;
+        }
+
+        return true;
+}

--- a/Common/ccryptkeys.h
+++ b/Common/ccryptkeys.h
@@ -1,0 +1,52 @@
+#ifndef _INC_CCRYPTKEYS_H
+#define _INC_CCRYPTKEYS_H
+#if _MSC_VER >= 1000
+#pragma once
+#endif
+
+#include "common.h"
+#include "carray.h"
+#include "cscript.h"
+
+// Encryption types supported by SphereCrypt.ini.
+enum CRYPT_TYPE
+{
+        CRYPT_NONE = 0,
+        CRYPT_BFISH,
+        CRYPT_BTFISH,
+        CRYPT_TFISH,
+        CRYPT_LOGIN,
+        CRYPT_QTY
+};
+
+struct CCryptClientKey
+{
+        DWORD m_uiClientVersion;
+        DWORD m_MasterHi;
+        DWORD m_MasterLo;
+        CRYPT_TYPE m_EncType;
+};
+
+class CCryptKeysManager
+{
+public:
+        static CCryptKeysManager & GetInstance();
+
+        void ResetToDefaults();
+        void AddKey(const CCryptClientKey & key);
+        bool FindKeyForVersion(DWORD uiVersion, CCryptClientKey & outKey) const;
+        const CCryptClientKey * GetKey(size_t index) const;
+        size_t GetKeyCount() const;
+        bool LoadKeyTable(CScript & script);
+
+private:
+        CCryptKeysManager();
+
+        void LoadDefaults();
+        void AddNoCryptKey();
+        CRYPT_TYPE ParseEncryptionType(const TCHAR * pszName) const;
+
+        CGTypedArray<CCryptClientKey, CCryptClientKey&> m_clientKeys;
+};
+
+#endif // _INC_CCRYPTKEYS_H

--- a/GraySvr/CServer.cpp
+++ b/GraySvr/CServer.cpp
@@ -2585,12 +2585,12 @@ scp_secure:
 
 bool CServer::LoadIni()
 {
-	CScriptLock s;
-	if ( ! s.OpenFind( GRAY_FILE ".ini" )) // Open script file
-	{
-		g_Log.Event( LOGL_FATAL|LOGM_INIT, "Can't open " GRAY_FILE ".ini\n" );
-		return( false );
-	}
+        CScriptLock s;
+        if ( ! s.OpenFind( GRAY_FILE ".ini" )) // Open script file
+        {
+                g_Log.Event( LOGL_FATAL|LOGM_INIT, "Can't open " GRAY_FILE ".ini\n" );
+                return( false );
+        }
 
 	while (s.FindNextSection())
 	{
@@ -2679,7 +2679,37 @@ bool CServer::LoadIni()
 			SetName( szName );
 	}
 
-	return( true );
+        return( true );
+}
+
+bool CServer::LoadCryptIni()
+{
+        CScriptLock s;
+        if ( ! s.OpenFind( GRAY_FILE "Crypt.ini" ) )
+        {
+                if ( ! s.OpenFind( "SphereCrypt.ini" ))
+                {
+                        g_Log.Event( LOGL_WARN|LOGM_INIT, "Could not open " GRAY_FILE "Crypt.ini, using built-in client keys.\n" );
+                        CCryptKeysManager::GetInstance().ResetToDefaults();
+                        return false;
+                }
+        }
+
+        bool fLoaded = CCryptKeysManager::GetInstance().LoadKeyTable( s );
+        if ( ! fLoaded )
+        {
+                g_Log.Event( LOGL_WARN|LOGM_INIT, "No valid entries in " GRAY_FILE "Crypt.ini, using built-in client keys.\n" );
+                return false;
+        }
+
+        g_Log.Event( LOGM_INIT, "Loaded %u client encryption keys.\n", (UINT)CCryptKeysManager::GetInstance().GetKeyCount() );
+
+        if ( m_ClientVersion.GetClientVersion() > 0 )
+        {
+                m_ClientVersion.SetClientVersion( m_ClientVersion.GetClientVersion() );
+        }
+
+        return true;
 }
 
 void CServer::SysMessage( const TCHAR * pStr ) const
@@ -3527,17 +3557,19 @@ bool CServer::Load()
 
 	if ( ! LoadIni())
 		return( false );
-	if ( ! LoadDefs())
-		return( false );
-	if ( ! LoadTables())
-		return( false );
-	if ( ! LoadScripts())
-		return( false );
+        if ( ! LoadDefs())
+                return( false );
+        if ( ! LoadTables())
+                return( false );
+        if ( ! LoadScripts())
+                return( false );
 
-	TCHAR szVersion[ 256 ];
-	m_ClientVersion.WriteClientVersion( szVersion );
-	g_Log.Event( LOGM_INIT, _TEXT("Client Version: '%s'\n"), szVersion );
-	if ( ! m_ClientVersion.IsValid())
+        LoadCryptIni();
+
+        TCHAR szVersion[ 256 ];
+        m_ClientVersion.WriteClientVersion( szVersion );
+        g_Log.Event( LOGM_INIT, _TEXT("Client Version: '%s'\n"), szVersion );
+        if ( ! m_ClientVersion.IsValid())
 	{
 		g_Log.Event( LOGL_WARN|LOGM_INIT, "Bad Client Version '%s', falling back to automatic detection.\n", szVersion );
 	}

--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -147,6 +147,7 @@
   <ItemGroup>
     <ClCompile Include="..\common\carray.cpp" />
     <ClCompile Include="..\common\ccrypt.cpp" />
+    <ClCompile Include="..\common\ccryptkeys.cpp" />
     <ClCompile Include="..\common\cexpression.cpp" />
     <ClCompile Include="..\common\cfile.cpp" />
     <ClCompile Include="..\common\cfilelist.cpp" />
@@ -200,6 +201,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\common\carray.h" />
+    <ClInclude Include="..\common\ccryptkeys.h" />
     <ClInclude Include="..\common\cassoc.h" />
     <ClInclude Include="..\common\cexpression.h" />
     <ClInclude Include="..\common\cfile.h" />

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -25,6 +25,7 @@ extern size_t DEBUG_ValidateAlloc( const void * pThis );
 #include "../common/graycom.h"	// put slashes this way for LINUX, WIN32 does not care.
 #include "../common/graymul.h"
 #include "../common/grayproto.h"
+#include "../common/ccryptkeys.h"
 #include "../common/cgrayinst.h"
 #include "../common/cregion.h"
 #include "../common/cgraymap.h"
@@ -5782,9 +5783,10 @@ public:
 #endif
 
 private:
-	bool LoadDefs();
-	bool LoadTables();
-	bool LoadScripts();
+        bool LoadDefs();
+        bool LoadTables();
+        bool LoadScripts();
+        bool LoadCryptIni();
 
 	void SetSignals();
 	void LoadChangedFiles();

--- a/GraySvr/makefile
+++ b/GraySvr/makefile
@@ -41,6 +41,7 @@ SRC	:= 	caccount.cpp \
 
 COMMONSRC	:=	../common/carray.cpp \
 			../common/ccrypt.cpp \
+			../common/ccryptkeys.cpp \
 			../common/cexpression.cpp \
 			../common/cfile.cpp \
 			../common/cgrayinst.cpp \


### PR DESCRIPTION
## Summary
- add a CCryptKeysManager that maintains client encryption keys loaded at runtime
- switch CCryptBase::SetClientVersion to resolve keys through the manager
- load SphereCrypt.ini during server startup and add the new module to the build system

## Testing
- `make -s` *(fails: no rule to make target '../common/carray.cpp', path casing issue present before change)*

------
