### PR TITLE
Refactor client handshake to cache crypt state

### DIFF
--- a/Common/graybase.h
+++ b/Common/graybase.h
@@ -426,15 +426,13 @@ private:
 	static unsigned char seed_table[2][CRYPT_GAMESEED_COUNT][2][CRYPT_GAMESEED_LENGTH];
 
 private:
-	void SetConnectType( CONNECT_TYPE type );
-	void SetEncryptionType( ENCRYPTION_TYPE type );
-	CONNECT_TYPE GetConnectType() const;
-	ENCRYPTION_TYPE GetEncryptionType() const;
-	void ResetGameStream();
-	void InitBlowFish();
-	void InitTwoFish();
-	void InitMD5( unsigned char * ucInitialize );
-	bool DecryptLogin( unsigned char * pOutput, const unsigned char * pInput, size_t outLen, size_t inLen );
+        void SetConnectType( CONNECT_TYPE type );
+        void SetEncryptionType( ENCRYPTION_TYPE type );
+        void ResetGameStream();
+        void InitBlowFish();
+        void InitTwoFish();
+        void InitMD5( unsigned char * ucInitialize );
+        bool DecryptLogin( unsigned char * pOutput, const unsigned char * pInput, size_t outLen, size_t inLen );
 	bool DecryptBlowFish( unsigned char * pOutput, const unsigned char * pInput, size_t outLen, size_t inLen );
 	bool DecryptTwoFish( unsigned char * pOutput, const unsigned char * pInput, size_t outLen, size_t inLen );
 	bool EncryptMD5( unsigned char * pOutput, const unsigned char * pInput, size_t outLen, size_t inLen );
@@ -445,11 +443,13 @@ private:
 	void InitTables();
 	void InitSeed( int iTable );
 public:
-	CCrypt();
-	void InitFast( DWORD dwIP, CONNECT_TYPE ctInit, bool fRelay = true );
-	bool Init( const BYTE *pvSeed, size_t iLen = 0, SERVER_TYPE type = SERVER_Auto, bool fIsClientKR = false );
-	bool Decrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
-	bool Encrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
+        CCrypt();
+        void InitFast( DWORD dwIP, CONNECT_TYPE ctInit, bool fRelay = true );
+        bool Init( const BYTE *pvSeed, size_t iLen = 0, SERVER_TYPE type = SERVER_Auto, bool fIsClientKR = false );
+        CONNECT_TYPE GetConnectType() const;
+        ENCRYPTION_TYPE GetEncryptionType() const;
+        bool Decrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
+        bool Encrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
 };
 
 class CCompressTree

--- a/GraySvr/CClient.cpp
+++ b/GraySvr/CClient.cpp
@@ -12,6 +12,9 @@ CClient::CClient( SOCKET client ) : CGSocket( client )
 	m_pChar = NULL;
 	m_pAccount = NULL;
 	m_Crypt.SetClientVersion( 0 );
+	m_iConnectType = CONNECT_UNK;
+	m_iEncryptionType = ENC_NONE;
+	m_fExpectingRelayCrypt = false;
 
 	m_fGameServer = false;	// act like a login server first.
 	m_pGMPage = NULL;

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -1199,6 +1199,9 @@ private:
 
 	// encrypt/decrypt stuff.
 	CCrypt m_Crypt;			// Client source communications are always encrypted.
+	CONNECT_TYPE m_iConnectType;	// Cached connection type negotiated with the client.
+	ENCRYPTION_TYPE m_iEncryptionType;	// Cached encryption type negotiated with the client.
+	bool m_fExpectingRelayCrypt;	// Expect the next packet to be double-encrypted.
 	static CCompressTree sm_xComp;
 	bool m_fGameServer;		// compress the output. (not a login server)
 
@@ -1228,6 +1231,8 @@ private:
 	void xSend( const void *pData, int length ); // Buffering send function
 	void xSendReady( const void *pData, int length ); // We could send the packet now if we wanted to but wait til we have more.
 	bool xCheckSize( int len );	// check packet.
+	bool xProcessClientSetup( CEvent * pEvent, int len );
+	void SyncCryptState();
 
 #ifdef NDEBUG
 	void xInit_DeCrypt_FindKey( const BYTE * pCryptData, int len );
@@ -1496,6 +1501,14 @@ public:
 	CAccount * GetAccount() const
 	{
 		return( m_pAccount );
+	}
+	CONNECT_TYPE GetConnectType() const
+	{
+		return( m_iConnectType );
+	}
+	ENCRYPTION_TYPE GetEncryptionType() const
+	{
+		return( m_iEncryptionType );
 	}
 	bool IsPriv( WORD flag ) const
 	{	// PRIV_GM


### PR DESCRIPTION
## Summary
- expose the negotiated connect/encryption type and cache them on CClient
- handle client setup through a new xProcessClientSetup helper and delay decryption until crypt init succeeds
- trigger RelayGameCryptStart for the first game packet and sync relay init with the cached state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9f3a6ec3c832c8c5d316397ed8d12