### PR TITLE
Propagate reported client version tracking

### DIFF
--- a/Source-X-master/src/game/clients/CClientLog.cpp
+++ b/Source-X-master/src/game/clients/CClientLog.cpp
@@ -177,7 +177,7 @@ bool CClient::addLoginErr(byte code)
 			break;
 	}
 
-	if ( GetNetState()->m_clientVersionNumber || GetNetState()->m_reportedVersionNumber )	// only reply the packet to valid clients
+	if ( GetNetState()->getCryptVersion() || GetNetState()->getReportedVersion() )	// only reply the packet to valid clients
 		new PacketLoginError(this, static_cast<PacketLoginError::Reason>(code));
 	GetNetState()->markReadClosed();
 	return false;
@@ -873,6 +873,8 @@ bool CClient::xProcessClientSetup( CEvent * pEvent, uint uiLen )
 	GetNetState()->detectAsyncMode();
 	SetConnectType( m_Crypt.GetConnectType() );
 
+	GetNetState()->setCryptVersionNumber(m_Crypt.GetClientVerNumber());
+
 	if ( !xCanEncLogin() )
 	{
 		addLoginErr((uchar)((m_Crypt.GetEncryptionType() == ENC_NONE? PacketLoginError::EncNoCrypt : PacketLoginError::EncCrypt) ));
@@ -964,12 +966,12 @@ bool CClient::xProcessClientSetup( CEvent * pEvent, uint uiLen )
 
 						if ( tmVerReported != 0 )
 						{
-							GetNetState()->m_reportedVersionNumber = tmVerReported;
+							GetNetState()->setReportedVersionNumber(tmVerReported);
 						}
 						else if ( tmVer != 0 )
 						{
 							m_Crypt.SetClientVerFromNumber(tmVer, false);
-							GetNetState()->m_clientVersionNumber = tmVer;
+							GetNetState()->setCryptVersionNumber(tmVer);
 						}
 
 						// client version change may toggle async mode, it's important to flush pending data to the client before this happens

--- a/Source-X-master/src/game/clients/CClientMsg.cpp
+++ b/Source-X-master/src/game/clients/CClientMsg.cpp
@@ -3120,8 +3120,20 @@ byte CClient::LogIn( CAccount * pAccount, CSString & sMsg )
 		return (PacketLoginError::Blocked);
 	}
 
-	m_pAccount = pAccount;
-	pAccount->OnLogin( this );
+		m_pAccount = pAccount;
+
+		if (CNetState* netState = GetNetState())
+		{
+			const dword reportedVersion = netState->getReportedVersion();
+			if (reportedVersion != 0)
+				netState->setReportedVersionNumber(reportedVersion);
+
+			const dword cryptVersion = netState->getCryptVersion();
+			if (cryptVersion != 0)
+				netState->setCryptVersionNumber(cryptVersion);
+		}
+
+		pAccount->OnLogin( this );
 
 	return( PacketLoginError::Success );
 }

--- a/Source-X-master/src/network/CNetState.h
+++ b/Source-X-master/src/network/CNetState.h
@@ -7,6 +7,7 @@
 #define _INC_CNETSTATE_H
 
 #include "../common/sphere_library/CSQueue.h"
+#include "../common/CUOClientVersion.h"
 #include "../common/sphereproto.h"
 #include "../sphere/containers.h"
 #include "CSocket.h"
@@ -89,7 +90,12 @@ public:
     GAMECLIENT_TYPE m_clientType;	// type of client
     dword m_clientVersionNumber;			// client version (encryption)
     dword m_reportedVersionNumber;		// client version (reported)
+    bool m_reportedVersionMismatchLogged;	// has a mismatch already been handled
     byte m_sequence;				// movement sequence
+
+protected:
+    void persistReportedVersion() const;
+    bool reconcileClientVersions();
 
 public:
     explicit CNetState(int id);
@@ -121,6 +127,10 @@ public:
     GAMECLIENT_TYPE getClientType(void) const { return m_clientType; };	// determined client type
     dword getCryptVersion(void) const { return m_clientVersionNumber; };		// version as determined by encryption
     dword getReportedVersion(void) const { return m_reportedVersionNumber; }; // version as reported by client
+
+    bool setCryptVersionNumber(dword version);          // update encryption-derived version
+    bool setReportedVersionNumber(dword version);       // update reported version
+    bool setReportedVersion(const CUOClientVersion& version);   // update reported version from CUOClientVersion
 
     void markReadClosed(void) volatile;		// mark socket as closed by read thread
     void markWriteClosed(void) volatile;	// mark socket as closed by write thread

--- a/Source-X-master/src/network/CNetworkInput.cpp
+++ b/Source-X-master/src/network/CNetworkInput.cpp
@@ -606,7 +606,7 @@ bool CNetworkInput::processUnknownClientData(CNetState* state, Packet* buffer)
                 const dword versionRevision = buffer->readInt32();
                 const dword versionPatch = buffer->readInt32();
                 const CUOClientVersion cver(versionMajor, versionMinor, versionRevision, versionPatch);
-                state->m_reportedVersionNumber = cver.GetLegacyVersionNumber();
+                state->setReportedVersion(cver);
 
                 DEBUG_MSG(("%x:New Login Handshake Detected. Client Version: %u.%u.%u.%u\n",
                     state->id(), versionMajor, versionMinor, versionRevision, versionPatch));
@@ -631,7 +631,7 @@ bool CNetworkInput::processUnknownClientData(CNetState* state, Packet* buffer)
             seed = buffer->readInt32();
         }
 
-        DEBUGNETWORK(("%x:Client connected with a seed of 0x%x (new handshake=%d, version=%u).\n", state->id(), seed, state->m_newseed ? 1 : 0, state->m_reportedVersionNumber));
+        DEBUGNETWORK(("%x:Client connected with a seed of 0x%x (new handshake=%d, version=%u).\n", state->id(), seed, state->m_newseed ? 1 : 0, state->getReportedVersion()));
 
         if (seed == 0)
         {

--- a/Source-X-master/src/network/receive.cpp
+++ b/Source-X-master/src/network/receive.cpp
@@ -2485,17 +2485,17 @@ bool PacketClientVersion::onReceive(CNetState* net)
 		CClient* client = net->getClient();
 		ASSERT(client);
 
-		dword version = CUOClientVersion(versionStr).GetLegacyVersionNumber();
-		net->m_reportedVersionNumber = version;
+		const CUOClientVersion version(versionStr);
+		net->setReportedVersion(version);
 		net->detectAsyncMode();
 
-		DEBUG_MSG(("Getting CliVersionReported %u\n", version));
-		if ((g_Serv.m_ClientVersion.GetClientVerNumber() != 0) && (g_Serv.m_ClientVersion.GetClientVerNumber() != version))
-			client->addLoginErr(PacketLoginError::BadVersion);
-        //we have asked client version in serverlist to configure character list and game feature.
-        if ( client->m_pAccount )
-                    client->m_pAccount->m_TagDefs.SetNum("ReportedCliVer", version);
-	}
+		const dword reportedVersion = net->getReportedVersion();
+
+		DEBUG_MSG(("Getting CliVersionReported %u\n", reportedVersion));
+		if ((g_Serv.m_ClientVersion.GetClientVerNumber() != 0) && (g_Serv.m_ClientVersion.GetClientVerNumber() != reportedVersion))
+                        client->addLoginErr(PacketLoginError::BadVersion);
+		// CNetState::setReportedVersion() stores the reported version for account/session tags
+        }
 
 	return true;
 }


### PR DESCRIPTION
## Summary
- add helpers on `CNetState` to store and reconcile crypt/reported client versions while persisting account and session tags
- update login and packet handling paths to call the new setters so reported versions flow through the pipeline automatically
- ensure account binding refreshes stored versions so downstream systems use the negotiated values

## Testing
- ⚠️ `cmake -S Source-X-master -B Source-X-master/build` *(fails: project requires CMake 3.29 while container has 3.28.3)*

------
