### PR TITLE
Fix crypt key handling and relay decryption

### DIFF
--- a/Common/ccrypt.cpp
+++ b/Common/ccrypt.cpp
@@ -1029,14 +1029,15 @@ bool CCrypt::LoginCryptStart( DWORD dwIP, const BYTE * pEvent, size_t inLen )
 				}
 			}
 		}
-		if ( fValid )
-		{
-			m_CryptMaskLo = maskLo;
-			m_CryptMaskHi = maskHi;
-			SetInitState( true );
-			return true;
-		}
-	return true;
+                if ( fValid )
+                {
+                        m_CryptMaskLo = maskLo;
+                        m_CryptMaskHi = maskHi;
+                        SetInitState( true );
+                        return true;
+                }
+        }
+        return false;
 }
 
 bool CCrypt::GameCryptStart( DWORD dwIP, const BYTE * pEvent, size_t inLen )
@@ -1103,10 +1104,15 @@ bool CCrypt::GameCryptStart( DWORD dwIP, const BYTE * pEvent, size_t inLen )
 
 bool CCrypt::RelayGameCryptStart( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen )
 {
-	m_fRelayPacket = false;
-	if ( !Decrypt( pOutput, pInput, outLen, inLen ))
-		return false;
-	return DecryptLogin( pOutput, pOutput, outLen, inLen );
+        m_fRelayPacket = false;
+        if ( !Decrypt( pOutput, pInput, outLen, inLen ))
+                return false;
+        return DecryptLogin( pOutput, pOutput, outLen, inLen );
+}
+
+bool CCrypt::DecryptRelayGame( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen )
+{
+        return RelayGameCryptStart( pOutput, pInput, outLen, inLen );
 }
 
 void CCrypt::InitTables()

--- a/Common/ccryptkeys.cpp
+++ b/Common/ccryptkeys.cpp
@@ -73,7 +73,7 @@ void CCryptKeysManager::AddNoCryptKey()
         m_clientKeys.Add(key);
 }
 
-void CCryptKeysManager::AddKey(const CCryptClientKey & key)
+void CCryptKeysManager::AddKey(CCryptClientKey key)
 {
         for ( int i = 0; i < m_clientKeys.GetCount(); ++i )
         {

--- a/Common/ccryptkeys.h
+++ b/Common/ccryptkeys.h
@@ -33,7 +33,7 @@ public:
         static CCryptKeysManager & GetInstance();
 
         void ResetToDefaults();
-        void AddKey(const CCryptClientKey & key);
+        void AddKey(CCryptClientKey key);
         bool FindKeyForVersion(DWORD uiVersion, CCryptClientKey & outKey) const;
         const CCryptClientKey * GetKey(size_t index) const;
         size_t GetKeyCount() const;

--- a/Common/graybase.h
+++ b/Common/graybase.h
@@ -449,6 +449,7 @@ public:
         CONNECT_TYPE GetConnectType() const;
         ENCRYPTION_TYPE GetEncryptionType() const;
         bool Decrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
+        bool DecryptRelayGame( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
         bool Encrypt( BYTE * pOutput, const BYTE * pInput, size_t outLen, size_t inLen );
 };
 

--- a/GraySvr/CClientLog.cpp
+++ b/GraySvr/CClientLog.cpp
@@ -497,12 +497,12 @@ bool CClient::xRecvData() // Receive message from client
 	if ( iDecryptLen > 0 )
 	{
 		BYTE * pDecrypt = m_bin.m_Raw + iPrev;
-		if ( m_fExpectingRelayCrypt )
-		{
-			if ( !m_Crypt.RelayGameCryptStart( pDecrypt, pDecrypt, iDecryptLen, iDecryptLen ))
-				return false;
-			m_fExpectingRelayCrypt = false;
-		}
+                if ( m_fExpectingRelayCrypt )
+                {
+                        if ( !m_Crypt.DecryptRelayGame( pDecrypt, pDecrypt, iDecryptLen, iDecryptLen ))
+                                return false;
+                        m_fExpectingRelayCrypt = false;
+                }
 		else
 		{
 			if ( !m_Crypt.Decrypt( pDecrypt, pDecrypt, iDecryptLen, iDecryptLen ))


### PR DESCRIPTION
## Summary
- add-by-value helper for crypt keys to satisfy array interface
- fix LoginCryptStart flow and expose a safe relay decryption wrapper
- update client log to use new relay wrapper instead of private helper

## Testing
- not run (windows-only build system)


------
https://chatgpt.com/codex/tasks/task_e_68ca63c48bf4832cbd649ef2cf137690