### PR TITLE
Ensure character names are unique at creation

### DIFF
--- a/GraySvr/CChar.cpp
+++ b/GraySvr/CChar.cpp
@@ -2579,7 +2579,7 @@ void CChar::InitPlayer(CEvent* pBin, CClient* pClient)
 		"!\"#$%&()*,/:;<=>?@[\\]^{|}~_+");
 
 	// check busy names
-	if (len < 1 || g_Serv.IsNameTaken(name))
+	if (len < 1 || g_Serv.IsNameTaken(name, this))
 	{
 		g_Log.Event(LOGL_WARN, "%x: Name '%s' is already taken for account '%s'\n",
 			pClient->GetSocket(), pBin->Create.m_name, pClient->GetAccount()->GetName());

--- a/GraySvr/CClientMsg.cpp
+++ b/GraySvr/CClientMsg.cpp
@@ -3231,7 +3231,7 @@ void CClient::Setup_CreateDialog() // All the character creation stuff
 	pChar->InitPlayer(&m_bin, this);
 
 	// CHECKNAME DUPLICAT - now here
-	if (g_Serv.IsNameTaken(pChar->GetName()))
+	if (g_Serv.IsNameTaken(pChar->GetName(), pChar))
 	{
 		g_Log.Event(LOGL_WARN, "%x: Name '%s' is already taken for account '%s'\n",
 			GetSocket(), pChar->GetName(), m_pAccount->GetName());

--- a/GraySvr/CServer.cpp
+++ b/GraySvr/CServer.cpp
@@ -8,32 +8,168 @@
 #include <string>
 #include <signal.h>
 #include <set>
+#include <algorithm>
+#include <cctype>
 
 #ifdef _WIN32
 #include "../common/cassoc.h"
 #endif
 
 //////////////////////////////////////////////////////////
-//CHECKNAME STUFF
-void CServer::LoadNames() {
-	std::ifstream saveFile("C:\\t\\sph\\sphere\\world\\sphereworld.scp"); //do normal path later, now testing
-	if (!saveFile.is_open()) {
-		g_Log.Event(LOGL_ERROR, "Failed to open names file.\n");
-		return;
-	}
+namespace
+{
+        static void TrimString(std::string &text)
+        {
+                size_t first = text.find_first_not_of(" \t\r\n");
+                if ( first == std::string::npos )
+                {
+                        text.clear();
+                        return;
+                }
 
-	std::string line;
-	while (std::getline(saveFile, line)) {
-		if (line.rfind("NAME=", 0) == 0) {
-			std::string characterName = line.substr(5);
-			m_takenNames.insert(characterName); 
-		}
-	}
-	saveFile.close(); 
+                size_t last = text.find_last_not_of(" \t\r\n");
+                text = text.substr(first, last - first + 1);
+        }
+
+        static std::string ToLowerCopy(const std::string &text)
+        {
+                std::string lower = text;
+                std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char ch)
+                {
+                        return static_cast<char>( ::tolower(ch) );
+                });
+                return lower;
+        }
 }
 
-bool CServer::IsNameTaken(const char* name) {
-	return m_takenNames.find(name) != m_takenNames.end(); 
+//CHECKNAME STUFF
+void CServer::LoadNames()
+{
+        m_takenNames.clear();
+
+        if ( m_sWorldBaseDir.IsEmpty())
+        {
+                g_Log.Event( LOGL_WARN, "World base directory not set. Unable to load character names.\n" );
+                return;
+        }
+
+        const char * const sNameFiles[] =
+        {
+                GRAY_FILE "world" GRAY_SCRIPT,
+                GRAY_FILE "chars" GRAY_SCRIPT
+        };
+
+        for ( size_t i = 0; i < COUNTOF(sNameFiles); ++i )
+        {
+                CGString sFilePath;
+                sFilePath.Format( "%s%s", (const TCHAR *) m_sWorldBaseDir, sNameFiles[i] );
+
+                std::ifstream saveFile( sFilePath );
+                if ( ! saveFile.is_open())
+                {
+                        g_Log.Event( LOGL_WARN, "Failed to open names file '%s'.\n", (const TCHAR *) sFilePath );
+                        continue;
+                }
+
+                std::string line;
+                bool fInWorldCharSection = false;
+                while ( std::getline( saveFile, line ))
+                {
+                        std::string::size_type commentPos = line.find( "//" );
+                        if ( commentPos != std::string::npos )
+                                line.erase( commentPos );
+
+                        TrimString( line );
+                        if ( line.empty())
+                                continue;
+
+                        if ( line[0] == ';' )
+                                continue;
+
+                        if ( line[0] == '[' )
+                        {
+                                size_t endPos = line.find( ']' );
+                                if ( endPos != std::string::npos )
+                                {
+                                        std::string section = line.substr( 1, endPos - 1 );
+                                        TrimString( section );
+                                        std::string lowerSection = ToLowerCopy( section );
+                                        fInWorldCharSection = ( lowerSection.compare( 0, 9, "worldchar" ) == 0 );
+                                }
+                                else
+                                {
+                                        fInWorldCharSection = false;
+                                }
+                                continue;
+                        }
+
+                        if ( ! fInWorldCharSection )
+                                continue;
+
+                        size_t equalPos = line.find( '=' );
+                        if ( equalPos == std::string::npos )
+                                continue;
+
+                        std::string key = line.substr( 0, equalPos );
+                        TrimString( key );
+                        std::string lowerKey = ToLowerCopy( key );
+                        if ( lowerKey != "name" )
+                                continue;
+
+                        std::string value = line.substr( equalPos + 1 );
+                        TrimString( value );
+                        if ( value.size() >= 2 &&
+                                (( value.front() == '"' && value.back() == '"' ) || ( value.front() == '\'' && value.back() == '\'' )))
+                        {
+                                value = value.substr( 1, value.size() - 2 );
+                        }
+                        TrimString( value );
+                        if ( value.empty())
+                                continue;
+
+                        m_takenNames.insert( ToLowerCopy( value ));
+                }
+        }
+
+        m_fNamesLoaded = true;
+}
+
+bool CServer::IsNameTaken( const char * name, const CChar * pIgnore )
+{
+        if ( name == NULL || name[0] == '\0' )
+                return false;
+
+        if ( ! m_fNamesLoaded )
+        {
+                LoadNames();
+        }
+
+        UINT uiCount = g_World.GetUIDCount();
+        for ( UINT i = 1; i < uiCount; ++i )
+        {
+                CObjBase * pObj = g_World.FindUID( i );
+                if ( pObj == NULL )
+                        continue;
+                if ( ! pObj->IsChar())
+                        continue;
+
+                CChar * pChar = STATIC_CAST <CChar *> ( pObj );
+                if ( pChar == pIgnore )
+                        continue;
+
+                const char * pszCharName = pChar->GetName();
+                if ( pszCharName == NULL || pszCharName[0] == '\0' )
+                        continue;
+                if ( ! strcmpi( pszCharName, name ))
+                        return true;
+        }
+
+        std::string lowerName( name );
+        std::transform( lowerName.begin(), lowerName.end(), lowerName.begin(), []( unsigned char ch )
+        {
+                return static_cast<char>( ::tolower( ch ));
+        });
+        return( m_takenNames.find( lowerName ) != m_takenNames.end());
 }
 
 
@@ -945,6 +1081,8 @@ CServer::CServer() : CServRef( GRAY_TITLE, SOCKET_LOCAL_ADDRESS )
 	m_iMapCacheTime = 2 * 60 * TICK_PER_SEC;
 	m_iSectorSleepMask = 0x1ff;
 
+	m_fNamesLoaded = false;
+
 	m_wDebugFlags = 0; //DEBUGF_NPC_EMOTE
 	m_fSecure = true;
 	m_iFreezeRestartTime = 10*TICK_PER_SEC;
@@ -966,9 +1104,7 @@ CServer::CServer() : CServRef( GRAY_TITLE, SOCKET_LOCAL_ADDRESS )
 	m_iDecay_Item = 30*60*TICK_PER_SEC;
 	m_iDecay_CorpsePlayer = 45*60*TICK_PER_SEC;
 	m_iDecay_CorpseNPC = 15*60*TICK_PER_SEC;
-	//Load names check
-	LoadNames();
-	// Accounts
+        // Accounts
 	m_nClientsMax = FD_SETSIZE-1;
 	m_fRequireEmail = false;
 	m_nGuestsMax = 0;

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -5611,7 +5611,7 @@ private:
 
 public:
 	void LoadNames();
-	bool IsNameTaken(const char* name); //CHECK NAME FOR DUPLICATES
+	bool IsNameTaken(const char* name, const CChar* pIgnore = NULL); //CHECK NAME FOR DUPLICATES
 	int  m_iExitCode;  // Just some error code to return to system.
 	WORD m_wExitFlag;	// identifies who caused the exit.
 
@@ -5714,7 +5714,8 @@ public:
 	int  m_iPickUpSpeed;
 
 private:
-	std::set<std::string> m_takenNames; //check dup name
+	std::set<std::string> m_takenNames; // cached character names from save files
+	bool m_fNamesLoaded;
 	// Web status pages.
 	CGObArray <CWebPageDef*> m_WebPages;
 


### PR DESCRIPTION
## Summary
- load saved character names from the configured world directory instead of a hardcoded path and normalize them for lookups
- extend the server-side name check to walk the live character list, allowing the caller to ignore the character being initialized
- update character creation code to use the new signature so duplicate names are rejected without blocking the freshly created character

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdc8b58e58832c8c8699024d17bcca