### PR TITLE
Implement MySQL world object persistence helpers

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -2,10 +2,13 @@
 #define _CWORLD_STORAGE_MYSQL_H_
 
 #include "../common/cstring.h"
+#include <functional>
 #include <vector>
 
 class CAccount;
+class CObjBase;
 class CRealTime;
+class CVarDefMap;
 struct in_addr;
 
 #ifdef _WIN32
@@ -24,6 +27,70 @@ class CWorldStorageMySQL
 public:
         CWorldStorageMySQL();
         ~CWorldStorageMySQL();
+
+        class Transaction
+        {
+        public:
+                explicit Transaction( CWorldStorageMySQL & storage, bool fAutoBegin = true );
+                ~Transaction();
+
+                bool Begin();
+                bool Commit();
+                void Rollback();
+                bool IsActive() const
+                {
+                        return m_fActive;
+                }
+
+        private:
+                CWorldStorageMySQL & m_Storage;
+                bool m_fActive;
+                bool m_fCommitted;
+        };
+
+        class UniversalRecord
+        {
+        public:
+                explicit UniversalRecord( CWorldStorageMySQL & storage );
+                UniversalRecord( CWorldStorageMySQL & storage, const CGString & table );
+
+                void SetTable( const CGString & table );
+                const CGString & GetTable() const
+                {
+                        return m_sTable;
+                }
+
+                void Clear();
+                bool Empty() const;
+
+                void SetRaw( const char * field, const CGString & expression );
+                void SetNull( const char * field );
+                void SetString( const char * field, const CGString & value );
+                void SetOptionalString( const char * field, const CGString & value );
+                void SetDateTime( const char * field, const CGString & value );
+                void SetDateTime( const char * field, const CRealTime & value );
+                void SetInt( const char * field, long long value );
+                void SetUInt( const char * field, unsigned long long value );
+                void SetBool( const char * field, bool value );
+
+                CGString BuildInsert( bool fReplace, bool fUpdateOnDuplicate ) const;
+                CGString BuildUpdate( const CGString & whereClause ) const;
+
+        private:
+                struct FieldEntry
+                {
+                        CGString m_sName;
+                        CGString m_sValue;
+                };
+
+                FieldEntry * FindField( const char * field );
+                const FieldEntry * FindField( const char * field ) const;
+                void AddOrReplaceField( const char * field, const CGString & value );
+
+                CWorldStorageMySQL & m_Storage;
+                CGString m_sTable;
+                std::vector<FieldEntry> m_Fields;
+        };
 
         struct AccountData
         {
@@ -59,10 +126,20 @@ public:
         bool IsLegacyImportCompleted();
         bool SetLegacyImportCompleted();
 
+        bool BeginTransaction();
+        bool CommitTransaction();
+        bool RollbackTransaction();
+        bool WithTransaction( const std::function<bool()> & callback );
+
         bool LoadAllAccounts( std::vector<AccountData> & accounts );
         bool LoadChangedAccounts( std::vector<AccountData> & accounts );
         bool UpsertAccount( const CAccount & account );
         bool DeleteAccount( const TCHAR * pszAccountName );
+
+        bool SaveWorldObject( CObjBase * pObject );
+        bool SaveWorldObjects( const std::vector<CObjBase*> & objects );
+        bool DeleteWorldObject( const CObjBase * pObject );
+        bool ClearWorldData();
 
         const CGString & GetTablePrefix() const
         {
@@ -70,6 +147,9 @@ public:
         }
 
 private:
+        friend class Transaction;
+        friend class UniversalRecord;
+
         bool Query( const CGString & query, MYSQL_RES ** ppResult = NULL );
         bool ExecuteQuery( const CGString & query );
         bool EnsureSchemaVersionTable();
@@ -77,6 +157,7 @@ private:
         bool ApplyMigration( int fromVersion );
         bool ApplyMigration_0_1();
         bool ApplyMigration_1_2();
+        bool ApplyMigration_2_3();
         bool EnsureColumnExists( const CGString & table, const char * column, const char * definition );
         bool ColumnExists( const CGString & table, const char * column ) const;
         bool FetchAccounts( std::vector<AccountData> & accounts, const CGString & whereClause );
@@ -92,6 +173,17 @@ private:
         void UpdateAccountSyncTimestamp( const std::vector<AccountData> & accounts );
         CGString GetPrefixedTableName( const char * name ) const;
 
+        bool SaveWorldObjectInternal( CObjBase * pObject );
+        bool SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
+        bool UpsertWorldObjectMeta( CObjBase * pObject, const CGString & serialized );
+        bool UpsertWorldObjectData( const CObjBase * pObject, const CGString & serialized );
+        bool RefreshWorldObjectComponents( const CObjBase * pObject );
+        bool RefreshWorldObjectRelations( const CObjBase * pObject );
+        void AppendVarDefComponents( const CGString & table, unsigned long long uid, const CVarDefMap * pMap, const TCHAR * pszComp, std::vector<UniversalRecord> & outRecords );
+        CGString ComputeSerializedChecksum( const CGString & serialized ) const;
+        bool ExecuteRecordsInsert( const std::vector<UniversalRecord> & records );
+        bool ClearTable( const CGString & table );
+
         void LogMySQLError( const char * context );
 
         MYSQL * m_pConnection;
@@ -101,6 +193,7 @@ private:
         int m_iReconnectTries;
         int m_iReconnectDelay;
         time_t m_tLastAccountSync;
+        int m_iTransactionDepth;
 };
 
 #endif // _CWORLD_STORAGE_MYSQL_H_


### PR DESCRIPTION
## Summary
- finalize the 2→3 schema migration strings and update the migrator to set version 3
- implement world-object save/delete/clear APIs with serialization, metadata, component, and relation refresh logic
- add utility helpers for bulk inserts, table cleanup, and serialized checksums to support the new workflow

## Testing
- make -C GraySvr *(fails: No rule to make target '../common/carray.cpp')*

------
https://chatgpt.com/codex/tasks/task_e_68ce66e1aef4832c9cd1dc21722ec715