### PR TITLE
Align MySQL migrations with documented schema

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -677,8 +677,8 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
                 "`name` VARCHAR(32) NOT NULL,"
                 "`password` VARCHAR(64) NOT NULL,"
                 "`plevel` INT NOT NULL DEFAULT 0,"
-                "`priv_flags` INT NOT NULL DEFAULT 0,"
-                "`status` INT NOT NULL DEFAULT 0,"
+                "`priv_flags` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`status` INT UNSIGNED NOT NULL DEFAULT 0,"
                 "`comment` TEXT NULL,"
                 "`email` VARCHAR(128) NULL,"
                 "`chat_name` VARCHAR(64) NULL,"
@@ -690,7 +690,7 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
                 "`first_ip` VARCHAR(45) NULL,"
                 "`first_login` DATETIME NULL,"
                 "`last_char_uid` BIGINT UNSIGNED NULL,"
-                "`email_failures` INT NOT NULL DEFAULT 0,"
+                "`email_failures` INT UNSIGNED NOT NULL DEFAULT 0,"
                 "`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
                 "`updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,"
                 "PRIMARY KEY (`id`),"
@@ -702,8 +702,8 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
         sQuery.Format(
                 "CREATE TABLE IF NOT EXISTS `%s` ("
                 "`account_id` INT UNSIGNED NOT NULL,"
-                "`sequence` INT NOT NULL,"
-                "`message_id` INT NOT NULL,"
+                "`sequence` SMALLINT UNSIGNED NOT NULL,"
+                "`message_id` SMALLINT UNSIGNED NOT NULL,"
                 "PRIMARY KEY (`account_id`, `sequence`),"
                 "FOREIGN KEY (`account_id`) REFERENCES `%s`(`id`) ON DELETE CASCADE"
                 ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
@@ -733,14 +733,14 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
 		"`uid` BIGINT UNSIGNED NOT NULL,"
 		"`container_uid` BIGINT UNSIGNED NULL,"
 		"`owner_uid` BIGINT UNSIGNED NULL,"
-		"`type` INT NOT NULL DEFAULT 0,"
-		"`amount` INT NOT NULL DEFAULT 0,"
-		"`color` INT NOT NULL DEFAULT 0,"
-		"`position_x` INT NULL,"
-		"`position_y` INT NULL,"
-		"`position_z` INT NULL,"
-		"`map_plane` INT NULL,"
-		"`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                "`type` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`amount` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`color` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`position_x` INT NULL,"
+                "`position_y` INT NULL,"
+                "`position_z` INT NULL,"
+                "`map_plane` INT NULL,"
+                "`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
 		"PRIMARY KEY (`uid`),"
 		"KEY `ix_items_container` (`container_uid`),"
 		"KEY `ix_items_owner` (`owner_uid`),"
@@ -782,12 +782,12 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
 		"`account_id` INT UNSIGNED NULL,"
 		"`character_uid` BIGINT UNSIGNED NULL,"
 		"`reason` TEXT NULL,"
-		"`status` INT NOT NULL DEFAULT 0,"
-		"`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
-		"PRIMARY KEY (`id`),"
-		"KEY `ix_gm_pages_account` (`account_id`),"
-		"KEY `ix_gm_pages_character` (`character_uid`),"
-		"FOREIGN KEY (`account_id`) REFERENCES `%s`(`id`) ON DELETE SET NULL,"
+                "`status` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                "PRIMARY KEY (`id`),"
+                "KEY `ix_gm_pages_account` (`account_id`),"
+                "KEY `ix_gm_pages_character` (`character_uid`),"
+                "FOREIGN KEY (`account_id`) REFERENCES `%s`(`id`) ON DELETE SET NULL,"
 		"FOREIGN KEY (`character_uid`) REFERENCES `%s`(`uid`) ON DELETE SET NULL"
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
 		(const char *) sGMPages, (const char *) sAccounts, (const char *) sCharacters );
@@ -799,13 +799,13 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
 		"`name` VARCHAR(64) NOT NULL,"
 		"`address` VARCHAR(128) NULL,"
 		"`port` INT NULL,"
-		"`status` INT NOT NULL DEFAULT 0,"
-		"`last_seen` DATETIME NULL,"
-		"PRIMARY KEY (`id`),"
-		"UNIQUE KEY `ux_servers_name` (`name`)"
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
-		(const char *) sServers );
-	vQueries.push_back( sQuery );
+                "`status` INT UNSIGNED NOT NULL DEFAULT 0,"
+                "`last_seen` DATETIME NULL,"
+                "PRIMARY KEY (`id`),"
+                "UNIQUE KEY `ux_servers_name` (`name`)"
+                ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+                (const char *) sServers );
+        vQueries.push_back( sQuery );
 
 	sQuery.Format(
 		"CREATE TABLE IF NOT EXISTS `%s` ("
@@ -813,12 +813,12 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
 		"`character_uid` BIGINT UNSIGNED NULL,"
 		"`item_uid` BIGINT UNSIGNED NULL,"
 		"`expires_at` BIGINT NOT NULL,"
-		"`type` INT NOT NULL,"
-		"`data` TEXT NULL,"
-		"PRIMARY KEY (`id`),"
-		"KEY `ix_timers_character` (`character_uid`),"
-		"KEY `ix_timers_item` (`item_uid`),"
-		"FOREIGN KEY (`character_uid`) REFERENCES `%s`(`uid`) ON DELETE CASCADE,"
+                "`type` INT UNSIGNED NOT NULL,"
+                "`data` TEXT NULL,"
+                "PRIMARY KEY (`id`),"
+                "KEY `ix_timers_character` (`character_uid`),"
+                "KEY `ix_timers_item` (`item_uid`),"
+                "FOREIGN KEY (`character_uid`) REFERENCES `%s`(`uid`) ON DELETE CASCADE,"
 		"FOREIGN KEY (`item_uid`) REFERENCES `%s`(`uid`) ON DELETE CASCADE"
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
 		(const char *) sTimers, (const char *) sCharacters, (const char *) sItems );
@@ -840,7 +840,7 @@ bool CWorldStorageMySQL::ApplyMigration_1_2()
         const CGString sAccounts = GetPrefixedTableName( "accounts" );
         const CGString sAccountEmails = GetPrefixedTableName( "account_emails" );
 
-        if ( ! EnsureColumnExists( sAccounts, "priv_flags", "`priv_flags` INT NOT NULL DEFAULT 0 AFTER `plevel`" ))
+        if ( ! EnsureColumnExists( sAccounts, "priv_flags", "`priv_flags` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `plevel`" ))
         {
                 return false;
         }
@@ -876,7 +876,7 @@ bool CWorldStorageMySQL::ApplyMigration_1_2()
         {
                 return false;
         }
-        if ( ! EnsureColumnExists( sAccounts, "email_failures", "`email_failures` INT NOT NULL DEFAULT 0 AFTER `last_char_uid`" ))
+        if ( ! EnsureColumnExists( sAccounts, "email_failures", "`email_failures` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `last_char_uid`" ))
         {
                 return false;
         }
@@ -889,8 +889,8 @@ bool CWorldStorageMySQL::ApplyMigration_1_2()
         sQuery.Format(
                 "CREATE TABLE IF NOT EXISTS `%s` ("
                 "`account_id` INT UNSIGNED NOT NULL,"
-                "`sequence` INT NOT NULL,"
-                "`message_id` INT NOT NULL,"
+                "`sequence` SMALLINT UNSIGNED NOT NULL,"
+                "`message_id` SMALLINT UNSIGNED NOT NULL,"
                 "PRIMARY KEY (`account_id`, `sequence`),"
                 "FOREIGN KEY (`account_id`) REFERENCES `%s`(`id`) ON DELETE CASCADE"
                 ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
@@ -934,6 +934,7 @@ bool CWorldStorageMySQL::ApplyMigration_2_3()
                 "KEY `ix_world_objects_type` (`object_type`),\n"
                 "KEY `ix_world_objects_account` (`account_id`),\n"
                 "KEY `ix_world_objects_container` (`container_uid`),\n"
+                "KEY `ix_world_objects_top` (`top_level_uid`),\n"
                 "FOREIGN KEY (`account_id`) REFERENCES `%s`(`id`) ON DELETE SET NULL,\n"
                 "FOREIGN KEY (`container_uid`) REFERENCES `%s`(`uid`) ON DELETE SET NULL,\n"
                 "FOREIGN KEY (`top_level_uid`) REFERENCES `%s`(`uid`) ON DELETE SET NULL\n"

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,189 @@
+# MySQL Schema Overview
+
+This project relies on a small number of MySQL tables that back account
+management and optional world state persistence. The following summary reflects
+schema version 3 as created by the migrations in
+`GraySvr/CWorldStorageMySQL.cpp`.
+
+## `schema_version`
+Stores the current schema revision as well as the flag that indicates whether
+a legacy import has been completed.
+
+| Column  | Type        | Notes                                 |
+| ------- | ----------- | ------------------------------------- |
+| id      | INT         | Primary key. 1 = schema, 2 = import.  |
+| version | INT         | Current version/flag value.           |
+
+## `accounts`
+Primary record for player accounts.
+
+| Column              | Type                       | Notes |
+| ------------------- | -------------------------- | ----- |
+| id                  | INT UNSIGNED AUTO_INCREMENT| Primary key. |
+| name                | VARCHAR(32)                | Unique login name. |
+| password            | VARCHAR(64)                | Stored credential (hashed or plaintext based on configuration). |
+| plevel              | INT                        | Privilege level. |
+| priv_flags          | INT UNSIGNED               | Bit field with auxiliary privileges. |
+| status              | INT UNSIGNED               | Bit field used for jailed/blocked states. |
+| comment             | TEXT                       | GM comment. |
+| email               | VARCHAR(128)               | Contact e-mail. |
+| chat_name           | VARCHAR(64)                | Optional chat handle. |
+| language            | CHAR(3)                    | ISO language code. |
+| total_connect_time  | INT                        | Accumulated connection time. |
+| last_connect_time   | INT                        | Duration of the last session. |
+| last_ip             | VARCHAR(45)                | Last IP address (IPv4/IPv6 textual representation). |
+| last_login          | DATETIME                   | Timestamp of the last login. |
+| first_ip            | VARCHAR(45)                | First IP used by the account. |
+| first_login         | DATETIME                   | Timestamp of the first login. |
+| last_char_uid       | BIGINT UNSIGNED            | UID of the last played character. |
+| email_failures      | INT UNSIGNED               | Failed e-mail delivery attempts. |
+| created_at          | DATETIME                   | Creation timestamp. |
+| updated_at          | DATETIME                   | Updated automatically via ON UPDATE. |
+
+*Indexes*: `PRIMARY KEY(id)` and `UNIQUE KEY ux_accounts_name(name)`.
+
+## `account_emails`
+Stores the scheduled mail queue for an account.
+
+| Column     | Type                | Notes |
+| ---------- | ------------------- | ----- |
+| account_id | INT UNSIGNED        | FK to `accounts.id`. |
+| sequence   | SMALLINT UNSIGNED   | Ordering for queued messages. |
+| message_id | SMALLINT UNSIGNED   | Message identifier. |
+
+*Indexes*: `PRIMARY KEY(account_id, sequence)` with a foreign key cascading on
+account deletion.
+
+## `characters` (legacy import staging)
+A simplified representation used by the import flow.
+
+| Column        | Type                | Notes |
+| ------------- | ------------------- | ----- |
+| uid           | BIGINT UNSIGNED     | Primary key. |
+| account_id    | INT UNSIGNED        | FK to `accounts.id`. |
+| name          | VARCHAR(64)         | Character name. |
+| body_id       | INT                 | Body tile identifier. |
+| position_x/y/z| INT                 | World coordinates. |
+| map_plane     | INT                 | Map plane. |
+| created_at    | DATETIME            | Creation time. |
+
+## `items` (legacy import staging)
+Container for legacy item serialization during migration.
+
+| Column         | Type                | Notes |
+| -------------- | ------------------- | ----- |
+| uid            | BIGINT UNSIGNED     | Primary key. |
+| container_uid  | BIGINT UNSIGNED     | Self-referencing container FK. |
+| owner_uid      | BIGINT UNSIGNED     | FK to `characters.uid`. |
+| type           | INT UNSIGNED        | Item type identifier. |
+| amount         | INT UNSIGNED        | Stack amount. |
+| color          | INT UNSIGNED        | Hue value. |
+| position_x/y/z | INT                 | Position within container/top-level. |
+| map_plane      | INT                 | Map plane. |
+| created_at     | DATETIME            | Creation time. |
+
+The table includes indexes on `container_uid` and `owner_uid` with cascading
+foreign keys for cleanup.
+
+## `item_props` (legacy import staging)
+Key-value store for serialized item properties.
+
+| Column  | Type            | Notes |
+| ------- | --------------- | ----- |
+| item_uid| BIGINT UNSIGNED | FK to `items.uid`. |
+| prop    | VARCHAR(64)     | Property name. |
+| value   | TEXT            | Property value. |
+
+Primary key: `(item_uid, prop)` with cascading delete on the item.
+
+## `sectors`, `gm_pages`, `servers`, `timers`
+Supporting tables for optional features mirrored from the legacy schema. The
+important column types are kept unsigned for identifiers/counters and respect
+the foreign keys laid out in the migrations.
+
+## World persistence tables (`schema` version ≥ 3)
+The following tables power MySQL backed world persistence.
+
+### `world_objects`
+Metadata for each object that appears in the world save.
+
+| Column         | Type                | Notes |
+| -------------- | ------------------- | ----- |
+| uid            | BIGINT UNSIGNED     | Primary key matching the Sphere UID. |
+| object_type    | VARCHAR(32)         | Either `char` or `item`. |
+| object_subtype | VARCHAR(64)         | Hex-encoded base ID. |
+| name           | VARCHAR(128)        | Optional display name. |
+| account_id     | INT UNSIGNED        | Owner account (characters only). |
+| container_uid  | BIGINT UNSIGNED     | Parent container when applicable. |
+| top_level_uid  | BIGINT UNSIGNED     | Top-level owner for containment resolution. |
+| position_x/y/z | INT                 | Cached location or container offset. |
+| created_at     | DATETIME            | Creation timestamp. |
+| updated_at     | DATETIME            | Auto-updated timestamp. |
+
+*Indexes*: keys on `object_type`, `account_id`, `container_uid`, and
+`top_level_uid` assist lookups for synchronization flows. Foreign keys keep the
+tree consistent and default to `SET NULL` for soft-orphan handling.
+
+### `world_object_data`
+Stores the serialized script blob of the object.
+
+| Column     | Type            | Notes |
+| ---------- | --------------- | ----- |
+| object_uid | BIGINT UNSIGNED | FK to `world_objects.uid`. |
+| data       | LONGTEXT        | Serialized object state. |
+| checksum   | VARCHAR(64)     | Hex digest of the serialized payload. |
+
+Primary key: `object_uid` with cascading delete.
+
+### `world_object_components`
+Breaks down TAG/VAR style dynamic properties.
+
+| Column      | Type            | Notes |
+| ----------- | --------------- | ----- |
+| object_uid  | BIGINT UNSIGNED | FK to `world_objects.uid`. |
+| component   | VARCHAR(32)     | Component category (e.g., `TAG`). |
+| name        | VARCHAR(128)    | Property name. |
+| sequence    | INT             | Stable ordering index. |
+| value       | LONGTEXT        | Optional value. |
+
+Primary key: `(object_uid, component, name, sequence)` with indexes on
+`component` to speed component fetches.
+
+### `world_object_relations`
+Represents parent/child relationships such as equipment or container contents.
+
+| Column     | Type            | Notes |
+| ---------- | --------------- | ----- |
+| parent_uid | BIGINT UNSIGNED | FK to `world_objects.uid`. |
+| child_uid  | BIGINT UNSIGNED | FK to `world_objects.uid`. |
+| relation   | VARCHAR(32)     | Relation name (`equipped`, `container`). |
+| sequence   | INT             | Ordering for siblings. |
+
+Composite primary key `(parent_uid, child_uid, relation, sequence)` with a
+secondary index on `child_uid` and cascading deletes on both foreign keys.
+
+### `world_savepoints`
+Book-keeping for manual world snapshots.
+
+| Column        | Type                | Notes |
+| ------------- | ------------------- | ----- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | Primary key. |
+| label         | VARCHAR(64)         | Optional label. |
+| created_at    | DATETIME            | Creation timestamp. |
+| objects_count | INT                 | Object count recorded in the snapshot. |
+| checksum      | VARCHAR(64)         | Integrity checksum. |
+
+### `world_object_audit`
+Audit log of object mutations.
+
+| Column     | Type                | Notes |
+| ---------- | ------------------- | ----- |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | Primary key. |
+| object_uid | BIGINT UNSIGNED     | FK to `world_objects.uid`. |
+| changed_at | DATETIME            | Timestamp of the change. |
+| change_type| VARCHAR(32)         | Type/category of modification. |
+| data_before| LONGTEXT            | Optional previous serialized state. |
+| data_after | LONGTEXT            | Optional new serialized state. |
+
+Indexes exist on `object_uid` to accelerate history lookups.
+


### PR DESCRIPTION
## Summary
- document the expected MySQL schema for the account and world persistence tables
- adjust migration DDL so column types and indexes match the documented structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6f3f274c832cb501a00b36842e15