### PR TITLE
Add dirty tracking and async MySQL persistence

### DIFF
--- a/GraySvr/CChar.cpp
+++ b/GraySvr/CChar.cpp
@@ -477,6 +477,7 @@ void CChar::Stat_Set( STAT_TYPE i, short iVal )
 	}
 	m_Stat[i] = iVal;
 	UpdateStatsFlag();
+	MarkDirty( StorageDirtyType_Save );
 }
 
 bool CChar::ReadScript( CScript &s, bool fRestock, bool fNewbie )
@@ -2842,6 +2843,10 @@ void CChar::UpdateStats( STAT_TYPE type, int iChange, int iLimit )
 		cmd.StatChng.m_val = m_StatVal[type].m_val;
 		m_pClient->xSendPkt( &cmd, sizeof(cmd.StatChng));
 	}
+	if ( iChange )
+	{
+		MarkDirty( StorageDirtyType_Save );
+	}
 }
 
 void CChar::UpdateAnimate( ANIM_TYPE action, bool fTranslate, bool fBackward, BYTE iFrameDelay )
@@ -3202,6 +3207,7 @@ void CChar::UpdateMove( CPointMap pold, CClient * pExcludeClient )
 {
 	// Who now sees this char ?
 	// Did they just see him move ?
+	MarkDirty( StorageDirtyType_Save );
 	for ( CClient * pClient = g_Serv.GetClientHead(); pClient!=NULL; pClient = pClient->GetNext())
 	{
 		if ( pClient == pExcludeClient ) 
@@ -4859,6 +4865,7 @@ bool CChar::MoveTo( CPointMap pt )
 	SetTopPoint( pt );
 
 	ASSERT( ! CObjBase::IsWeird());
+	MarkDirty( StorageDirtyType_Save );
 	return true;
 }
 

--- a/GraySvr/CContain.cpp
+++ b/GraySvr/CContain.cpp
@@ -11,6 +11,11 @@ void CContainer::OnWeightChange( int iChange )
 	// Propagate the weight change up the stack if there is one.
 	m_totalweight += iChange;
 	DEBUG_CHECK( m_totalweight >= 0 );
+	CObjBase * pObj = dynamic_cast<CObjBase*>( this );
+	if ( pObj != NULL )
+	{
+		pObj->MarkDirty( StorageDirtyType_Save );
+	}
 }
 
 int CContainer::FixWeight()
@@ -46,6 +51,7 @@ void CContainer::ContentAddPrivate( CItem * pItem )
 	}
 	CGObList::InsertAfter( pItem );
 	OnWeightChange( pItem->GetWeight());
+	pItem->MarkDirty( StorageDirtyType_Save );
 }
 
 void CContainer::OnRemoveOb( CGObListRec* pObRec )	// Override this = called when removed from list.

--- a/GraySvr/CItem.cpp
+++ b/GraySvr/CItem.cpp
@@ -1192,6 +1192,7 @@ bool CItem::MoveTo( CPointMap pt ) // Put item on the ground here.
 	ASSERT( ! CObjBase::IsWeird());
 
 	Update();
+	MarkDirty( StorageDirtyType_Save );
 	return( true );
 }
 
@@ -1570,6 +1571,14 @@ bool CItem::SetName( const TCHAR * pszName )
 	return SetNamePool( pszName );
 }
 
+void CItem::SetAttr( WORD wAttr )
+{
+	if ( m_Attr == wAttr )
+		return;
+	m_Attr = wAttr;
+	MarkDirty( StorageDirtyType_Save );
+}
+
 bool CItem::SetBase( CItemBase * pDef )
 {
 	// Total change of type. (possibly dangerous)
@@ -1599,6 +1608,7 @@ bool CItem::SetBase( CItemBase * pDef )
 	}
 
 	m_type = m_pDef->m_type;	// might change the type.
+	MarkDirty( StorageDirtyType_Save );
 	return( true );
 }
 
@@ -1628,6 +1638,7 @@ bool CItem::SetDispID( ITEMID_TYPE id )
 			return( false );
 	}
 
+	ITEMID_TYPE idPrev = m_id;
 	if ( CItemBase::IsValidDispID(id))
 	{
 		m_id = id;
@@ -1637,7 +1648,12 @@ bool CItem::SetDispID( ITEMID_TYPE id )
 	{
 		m_id = m_pDef->GetDispID();
 	}
-	
+
+	if ( idPrev != m_id )
+	{
+		MarkDirty( StorageDirtyType_Save );
+	}
+
 	return( true );
 }
 
@@ -1665,6 +1681,8 @@ void CItem::SetAmount( int amount )
 		ASSERT( IsEquipped() || IsInContainer());
 		pParentCont->OnWeightChange(( amount - oldamount ) * m_pDef->GetWeight());
 	}
+
+	MarkDirty( StorageDirtyType_Save );
 }
 
 void CItem::SetAmountUpdate( int amount )
@@ -1962,7 +1980,7 @@ bool CItem::r_LoadVal( CScript & s ) // Load an item Script
 		SetAmount( s.GetArgVal());
 		return true;
 	case 1: // "ATTR"
-		m_Attr = s.GetArgHex();
+		SetAttr( s.GetArgHex());
 		return true;
 	case 2:	// "CONT" needs special processing.
 		// Loading or import.

--- a/GraySvr/CWorld.cpp
+++ b/GraySvr/CWorld.cpp
@@ -478,10 +478,16 @@ void CWorld::NotifyStorageObjectRemoved( CObjBase * pObj )
 	if ( pStorage == NULL || ! pStorage->IsEnabled())
 		return;
 
+	if ( pObj->IsStorageDeleted())
+		return;
+
 	if ( ! pStorage->DeleteObject( pObj ))
 	{
 		g_Log.Event( LOGM_SAVE|LOGL_WARN, "Failed to mark object 0%lx as deleted in MySQL.\n", (unsigned long) pObj->GetUID());
+		return;
 	}
+
+	pObj->MarkDirty( StorageDirtyType_Delete );
 }
 
 void CWorld::FlushDeletedObjects()

--- a/GraySvr/ccharskill.cpp
+++ b/GraySvr/ccharskill.cpp
@@ -138,8 +138,13 @@ short CChar::Skill_GetAdjusted( SKILL_TYPE skill ) const
 void CChar::Skill_SetBase( SKILL_TYPE skill, short wValue )
 {
 	ASSERT( IsSkillBase(skill));
+	short wPrevValue = m_Skill[skill];
 	if ( wValue < 0 ) wValue = 0;
 	m_Skill[skill] = wValue;
+	if ( wPrevValue != wValue )
+	{
+		MarkDirty( StorageDirtyType_Save );
+	}
 	if ( IsClient())
 	{
 		// Update the skills list


### PR DESCRIPTION
## Summary
- add StorageDirtyType tracking and MarkDirty method to base objects
- queue dirty objects for asynchronous MySQL persistence and hook deletions
- mark char, item, and account mutations as dirty so updates are saved automatically

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce8a4176a0832cb8de7c298b724b05