### PR TITLE
Fix MySQL header include for Windows builds

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -24,7 +24,7 @@ struct in_addr;
 #ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>
-#include <winsock/mysql.h>
+#include <mysql.h>
 #else
 #include <mysql/mysql.h>
 #endif


### PR DESCRIPTION
## Summary
- replace the obsolete winsock/mysql.h include with mysql.h when building on Windows so Visual Studio can find the MySQL headers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce9ac6ffe8832cbc4631280023abd9