### PR TITLE
Fix Winsock include order for Windows builds

### DIFF
--- a/Common/graycom.h
+++ b/Common/graycom.h
@@ -37,8 +37,9 @@
 #define STRICT			// strict conversion of handles and pointers.
 #endif	// STRICT
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
-#include <winsock.h>
 #include <dos.h>
 #include <limits.h>
 #include <conio.h>


### PR DESCRIPTION
## Summary
- include WinSock2 headers before Windows headers in graycom.h
- add ws2tcpip include to keep socket definitions available while avoiding WinSock header conflicts

## Testing
- not run (Windows-specific build)

------
https://chatgpt.com/codex/tasks/task_e_68ceab48ae44832cbf679b4cfe6d1c3f