### PR TITLE
Fix Windows include order and constant array size

### DIFF
--- a/Common/graycom.h
+++ b/Common/graycom.h
@@ -37,6 +37,14 @@
 #define STRICT			// strict conversion of handles and pointers.
 #endif	// STRICT
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>

--- a/GraySvr/CClient.cpp
+++ b/GraySvr/CClient.cpp
@@ -1602,7 +1602,7 @@ bool CClient::Cmd_Skill_Tracking( int track_sel, bool fExec )
 			track_sel = COUNTOF(Track_Brain)-1;
 		NPCBRAIN_TYPE track_type = Track_Brain[ track_sel ];
 
-		CMenuItem item[ min( MAX_MENU_ITEMS, COUNTOF( m_tmMenu )) ];
+		CMenuItem item[MAX_MENU_ITEMS];
 		int count = 0;
 
 		item[0].m_id = TARGMODE_MENU_SKILL_TRACK;
@@ -1752,7 +1752,7 @@ bool CClient::Cmd_Skill_Menu( SKILL_TYPE iSkill, int iOffset, int iSelect )
 	if ( ! s.ReadKey())
 		return( false );
 
-	CMenuItem item[ min( COUNTOF( m_tmMenu ), MAX_MENU_ITEMS ) ];
+	CMenuItem item[MAX_MENU_ITEMS];
 	if ( iSelect < 0 )
 	{
 		item[0].m_id = TARGMODE_MENU_SKILL;

--- a/GraySvr/CServer.cpp
+++ b/GraySvr/CServer.cpp
@@ -2,9 +2,6 @@
 // CServer.cpp
 // Copyright Menace Software (www.menasoft.com).
 //
-#ifdef _WIN32
-#include <windows.h>
-#endif
 #ifndef _WIN32
 #include <sys/select.h>
 #include <sys/time.h>

--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -22,6 +22,12 @@ class CServRef;
 struct in_addr;
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <winsock2.h>
 #include <windows.h>
 #include <mysql.h>


### PR DESCRIPTION
## Summary
- define WIN32_LEAN_AND_MEAN and NOMINMAX before including Windows headers used by the server
- rely on the common header to provide Windows includes and remove the redundant include in CServer.cpp
- replace runtime min() usage with compile-time constants for menu arrays in CClient.cpp

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ceac318a90832c9087d2ef4ff3b0a6