### PR TITLE
Log MySQL errors through standard server logger

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -288,6 +288,7 @@ private:
         bool ClearTable( const CGString & table );
         CGString GetAccountNameById( unsigned int accountId );
 
+        WORD GetMySQLErrorLogMask( LOGL_TYPE level ) const;
         void LogMySQLError( const char * context );
 
         MYSQL * m_pConnection;


### PR DESCRIPTION
## Summary
- add a helper to compute the proper log mask for MySQL errors based on the server load state
- update the MySQL query helpers to use the standard server error logging path so failures reach the log files
- route LogMySQLError through the new helper and provide a fallback message when the MySQL client returns no text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ceb3fc8594832cb439d7058db7266c