### PR TITLE
Flush console input before waiting on exit

### DIFF
--- a/GraySvr/graysvr.cpp
+++ b/GraySvr/graysvr.cpp
@@ -653,7 +653,13 @@ int CLog::EventStr(WORD wMask, const TCHAR* pszMsg)
 
 		const TCHAR* pszLabel = NULL;
 
-		switch (wMask & 0x07)
+		const LOGL_TYPE eSeverity = (LOGL_TYPE)( wMask & 0x07 );
+		if ( eSeverity <= LOGL_CRIT )
+		{
+			m_fCriticalLogged = true;
+		}
+
+		switch ( eSeverity )
 		{
 		case LOGL_FATAL:   // fatal error!
 			pszLabel = "FATAL:";
@@ -974,15 +980,27 @@ world_bail:
 	if ( g_Serv.m_iExitCode )
 	{
 		g_Log.Event( LOGL_FATAL, "Server terminated by error %d!\n", g_Serv.m_iExitCode );
-#ifdef _WIN32
-		g_Serv.SysMessage( "Press any key to exit" );
-		while ( _getch() == 0 ) ;
-#endif
 	}
 	else
 	{
 		g_Log.Event( LOGL_EVENT, "Server shutdown complete!\n");
 	}
+
+#ifdef _WIN32
+        if ( g_Serv.m_iExitCode || g_Log.HasLoggedCritical())
+        {
+                const HANDLE hConsoleIn = GetStdHandle(STD_INPUT_HANDLE);
+                if ( hConsoleIn != INVALID_HANDLE_VALUE )
+                {
+                        FlushConsoleInputBuffer(hConsoleIn);
+                }
+
+                g_Serv.SysMessage( "Press any key to exit" );
+                fflush(stdout);
+                while ( _getch() == 0 ) ;
+        }
+#endif
+
 	g_Log.Close();
 
 	return( g_Serv.m_iExitCode );

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -167,6 +167,7 @@ private:
 	CRealTime m_Stamp;			// last real time stamp.
 	CGString m_sBaseDir;
 	const CScript * m_pScriptContext;	// The current context.
+	bool m_fCriticalLogged;	// Has a critical (or fatal) message been written?
 
 public:
 	const CScript * SetScriptContext( const CScript * pScriptContext )
@@ -186,6 +187,7 @@ public:
 		m_wMsgMask = LOGL_EVENT |
 			LOGM_INIT | LOGM_CLIENTS_LOG | LOGM_GM_PAGE;
 		SetFilePath( GRAY_FILE "log.log" );	// default name to go to.
+		m_fCriticalLogged = false;
 	}
 
 	bool Open( TCHAR * pszName = NULL );	// name set previously.
@@ -213,6 +215,11 @@ public:
 	{
 		return( IsLoggedMask(wMask) ||
 			( GetLogLevel() >= ( wMask & 0x0f )));
+	}
+
+	bool HasLoggedCritical() const
+	{
+		return( m_fCriticalLogged );
 	}
 
 	void Dump( const BYTE * pData, int len );


### PR DESCRIPTION
## Summary
- flush any pending keyboard input before prompting to keep the console open
- explicitly flush stdout so the shutdown prompt is visible before waiting for a key

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cec0ec0484832c8404820b59d374f4