### PR TITLE
Keep Windows console open until key press

### DIFF
--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -167,6 +167,7 @@ private:
 	CRealTime m_Stamp;			// last real time stamp.
 	CGString m_sBaseDir;
 	const CScript * m_pScriptContext;	// The current context.
+	bool m_fCriticalLogged;	// Has a fatal, critical, or error message been written?
 
 public:
 	const CScript * SetScriptContext( const CScript * pScriptContext )
@@ -186,6 +187,7 @@ public:
 		m_wMsgMask = LOGL_EVENT |
 			LOGM_INIT | LOGM_CLIENTS_LOG | LOGM_GM_PAGE;
 		SetFilePath( GRAY_FILE "log.log" );	// default name to go to.
+		m_fCriticalLogged = false;
 	}
 
 	bool Open( TCHAR * pszName = NULL );	// name set previously.
@@ -213,6 +215,11 @@ public:
 	{
 		return( IsLoggedMask(wMask) ||
 			( GetLogLevel() >= ( wMask & 0x0f )));
+	}
+
+	bool HasLoggedCritical() const
+	{
+		return( m_fCriticalLogged );
 	}
 
 	void Dump( const BYTE * pData, int len );


### PR DESCRIPTION
## Summary
- always wait for a keypress before closing the Windows console when a console handle is available
- flush pending console input and tailor the exit prompt when errors were logged

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cec0ec0484832c8404820b59d374f4