### PR TITLE
Handle MySQL charset and collation negotiation

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -276,6 +276,8 @@ private:
         void UpdateAccountSyncTimestamp( const std::vector<AccountData> & accounts );
         CGString GetPrefixedTableName( const char * name ) const;
         const char * GetDefaultTableCharset() const;
+        const char * GetDefaultTableCollation() const;
+        CGString GetDefaultTableCollationSuffix() const;
 
         bool SaveWorldObjectInternal( CObjBase * pObject );
         bool SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
@@ -293,6 +295,7 @@ private:
         CGString m_sTablePrefix;
         CGString m_sDatabaseName;
         CGString m_sTableCharset;
+        CGString m_sTableCollation;
         bool m_fAutoReconnect;
         int m_iReconnectTries;
         int m_iReconnectDelay;


### PR DESCRIPTION
## Summary
- negotiate the MySQL connection character set and collation, fall back when necessary, and log the chosen values before starting the worker thread
- add helpers to track a default table collation and compute a COLLATE clause suffix
- apply the selected collation when creating or migrating tables so schema definitions follow the negotiated charset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cedafcd4fc832ca41559e4e3002ccb