### PR TITLE
Fix missing collation suffix initialization

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -1261,6 +1261,7 @@ bool CWorldStorageMySQL::ApplyMigration_0_1()
 
 	std::vector<CGString> vQueries;
 	CGString sQuery;
+	CGString sCollationSuffix = GetDefaultTableCollationSuffix();
 
         sQuery.Format(
                 "CREATE TABLE IF NOT EXISTS `%s` ("


### PR DESCRIPTION
## Summary
- initialize the default table collation suffix before it is used when preparing schema migration queries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceeaf8bda4832c92974bda37300516