### PR TITLE
Fix forward declaration for StorageDirtyType

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -37,6 +37,7 @@ struct in_addr;
 
 
 struct CServerMySQLConfig;
+enum StorageDirtyType : int;
 
 class CWorldStorageMySQL
 {

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -450,7 +450,7 @@ enum NPC_MEM_ACT_TYPE	// A simgle primary memory about the object.
 	NPC_MEM_ACT_IGNORE,			// I looted or looked at and discarded this item (ignore it)
 };
 
-enum StorageDirtyType
+enum StorageDirtyType : int
 {
         StorageDirtyType_None = 0,
         StorageDirtyType_Save,


### PR DESCRIPTION
## Summary
- forward declare `StorageDirtyType` in `CWorldStorageMySQL.h`
- specify the `StorageDirtyType` underlying type in `graysvr.h` so the forward declaration is valid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ceec5e8150832ca9ec84c3dedfc92b