### PR TITLE
Add default MySQL library search path

### DIFF
--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -91,7 +91,7 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Release\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>wsock32.lib;libmysql.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.10</Version>
     </Link>
@@ -137,7 +137,7 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Debug\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>wsock32.lib;libmysql.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.12</Version>
     </Link>


### PR DESCRIPTION
## Summary
- add the repository MySQL Connector/C lib directory to the project's linker search path so libmysql.lib is found without environment variables

## Testing
- not run (project configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf24aa98c4832c83f5a2a02e9a1251