### PR TITLE
Undefine Windows min/max macros for MySQL storage

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -1,6 +1,13 @@
 #include "graysvr.h"
 #include "CWorldStorageMySQL.h"
 
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>


### PR DESCRIPTION
## Summary
- undefine Windows min and max macros before using std::max in CWorldStorageMySQL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb3b9fcd0832c9a2e5cfdb7437882