### PR TITLE
Adjust charset selection logic

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -1436,9 +1436,24 @@ bool CWorldStorageMySQL::Connect( const CServerMySQLConfig & config )
                                 sRequestedCharsetName = pszRequestedCharset;
                         }
 
-                        if ( !sDerivedCollation.IsEmpty() && ( pszRequestedCharset == NULL || strcmpi( pszRequestedCharset, (const char *) sDerivedCollation ) == 0 ) )
+                        if ( !sDerivedCollation.IsEmpty() )
                         {
-                                sRequestedCharsetName = sConnectionCharset;
+                                const bool fRequestedCharsetEmpty = ( pszRequestedCharset == NULL || pszRequestedCharset[0] == '\0' );
+                                bool fMatchesDerivedCharset = false;
+
+                                if ( !fRequestedCharsetEmpty )
+                                {
+                                        std::string sDerivedCharset = deriveCharsetFromCollationName( (const char *) sDerivedCollation );
+                                        if ( !sDerivedCharset.empty() )
+                                        {
+                                                fMatchesDerivedCharset = ( strcmpi( pszRequestedCharset, sDerivedCharset.c_str() ) == 0 );
+                                        }
+                                }
+
+                                if ( fRequestedCharsetEmpty || fMatchesDerivedCharset )
+                                {
+                                        sRequestedCharsetName = sConnectionCharset;
+                                }
                         }
 
                         CGString sPreferredTableCollation;


### PR DESCRIPTION
## Summary
- compare requested charset to the charset derived from the collation name
- only replace the requested charset when it matches the derived charset or is empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd58aa7a4832c93eb3b770d23bcad