### PR TITLE
Fix PowerShell download path binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+third_party/_downloads/
+third_party/mariadb-connector-c-*/

--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -72,7 +72,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Midl>
       <TypeLibraryName>.\Release\GraySvr.tlb</TypeLibraryName>
@@ -91,8 +91,8 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Release\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>wsock32.lib;libmysql.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wsock32.lib;libmariadb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.10</Version>
     </Link>
   </ItemDefinitionGroup>
@@ -118,7 +118,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Sync</ExceptionHandling>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Midl>
       <TypeLibraryName>.\Debug\GraySvr.tlb</TypeLibraryName>
@@ -137,8 +137,8 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Debug\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>wsock32.lib;libmysql.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wsock32.lib;libmariadb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.12</Version>
     </Link>
   </ItemDefinitionGroup>

--- a/GraySvr/Makefile.txt
+++ b/GraySvr/Makefile.txt
@@ -37,11 +37,33 @@ SRC := $(wildcard *.cpp)
 
 # Exe file
 # INCLUDE = -Ih -I/usr/ea/h
-INCLUDE += -I/usr/include/mysql
 
-# Default libraries
-LIBS += -L/usr/lib/mysql
-LIBS += -lmysqlclient
+# MariaDB Connector/C downloaded via `scripts/fetch_mariadb_connector.bat`.
+# Override `MARIADB_DIR` when targeting a custom installation.
+MARIADB_DIR ?= ../third_party/mariadb-connector-c-3.3.8-linux
+MARIADB_CONFIG_LOCAL := $(abspath $(MARIADB_DIR))/bin/mariadb_config
+MARIADB_CONFIG_SYSTEM := $(shell command -v mariadb_config 2>/dev/null)
+MYSQL_CONFIG_SYSTEM   := $(shell command -v mysql_config 2>/dev/null)
+
+ifneq ($(wildcard $(MARIADB_CONFIG_LOCAL)),)
+INCLUDE += $(shell $(MARIADB_CONFIG_LOCAL) --cflags 2>/dev/null)
+LIBS    += $(shell $(MARIADB_CONFIG_LOCAL) --libs 2>/dev/null)
+else ifneq ($(wildcard $(MARIADB_DIR)/include),)
+INCLUDE += -I$(MARIADB_DIR)/include -I$(MARIADB_DIR)/include/mariadb -I$(MARIADB_DIR)/include/mariadb/mysql
+LIBS    += -L$(MARIADB_DIR)/lib/mariadb -lmariadb
+else ifneq ($(strip $(MARIADB_CONFIG_SYSTEM)),)
+INCLUDE += $(shell $(MARIADB_CONFIG_SYSTEM) --cflags 2>/dev/null)
+LIBS    += $(shell $(MARIADB_CONFIG_SYSTEM) --libs 2>/dev/null)
+else ifneq ($(strip $(MYSQL_CONFIG_SYSTEM)),)
+INCLUDE += $(shell $(MYSQL_CONFIG_SYSTEM) --cflags 2>/dev/null)
+LIBS    += $(shell $(MYSQL_CONFIG_SYSTEM) --libs 2>/dev/null)
+endif
+
+# Legacy system-wide MySQL headers/libraries can still be injected manually if
+# desired, for example:
+#INCLUDE += -I/usr/include/mysql
+#LIBS += -L/usr/lib/mysql
+#LIBS += -lmysqlclient
 
 #LIBS += -lc_p
 #LIBS += -lefence

--- a/GraySvr/makefile
+++ b/GraySvr/makefile
@@ -26,11 +26,27 @@ OPT            ?=
 CXXFLAGS       += $(WARN) $(OPT) -pipe
 CPPFLAGS       += -DGRAY_SVR -I../Common
 
-# Ask `mysql_config` for the necessary include and library flags.  This keeps
-# the build portable across distributions where MySQL headers and libraries
-# might live in different directories.
-MYSQL_CFLAGS   := $(shell mysql_config --cflags 2>/dev/null)
-MYSQL_LIBS     := $(shell mysql_config --libs 2>/dev/null)
+# Ask a MariaDB/MySQL config helper for the necessary include and library
+# flags.  Preference is given to the MariaDB Connector/C drop that
+# `scripts/fetch_mariadb_connector.bat` installs under `../third_party`, while
+# still falling back to any system-wide mariadb_config/mysql_config helpers.
+MARIADB_DIR            ?= ../third_party/mariadb-connector-c-3.3.8-linux
+MARIADB_CONFIG_LOCAL   := $(abspath $(MARIADB_DIR))/bin/mariadb_config
+MARIADB_CONFIG_SYSTEM  := $(shell command -v mariadb_config 2>/dev/null)
+MYSQL_CONFIG_SYSTEM    := $(shell command -v mysql_config 2>/dev/null)
+
+ifeq ($(wildcard $(MARIADB_CONFIG_LOCAL)),)
+  ifneq ($(strip $(MARIADB_CONFIG_SYSTEM)),)
+    MYSQL_CFLAGS   := $(shell $(MARIADB_CONFIG_SYSTEM) --cflags 2>/dev/null)
+    MYSQL_LIBS     := $(shell $(MARIADB_CONFIG_SYSTEM) --libs 2>/dev/null)
+  else ifneq ($(strip $(MYSQL_CONFIG_SYSTEM)),)
+    MYSQL_CFLAGS   := $(shell $(MYSQL_CONFIG_SYSTEM) --cflags 2>/dev/null)
+    MYSQL_LIBS     := $(shell $(MYSQL_CONFIG_SYSTEM) --libs 2>/dev/null)
+  endif
+else
+  MYSQL_CFLAGS     := $(shell $(MARIADB_CONFIG_LOCAL) --cflags 2>/dev/null)
+  MYSQL_LIBS       := $(shell $(MARIADB_CONFIG_LOCAL) --libs 2>/dev/null)
+endif
 
 ifneq ($(strip $(MYSQL_CFLAGS)),)
 CPPFLAGS       += $(MYSQL_CFLAGS)
@@ -38,6 +54,16 @@ endif
 
 ifneq ($(strip $(MYSQL_LIBS)),)
 LDLIBS         += $(MYSQL_LIBS)
+endif
+
+ifneq ($(wildcard $(MARIADB_DIR)/include),)
+CPPFLAGS       += -I$(MARIADB_DIR)/include -I$(MARIADB_DIR)/include/mysql
+endif
+
+ifneq ($(strip $(MYSQL_LIBS)),)
+RPATH_DIRS     := $(patsubst -L%,%,$(filter -L%,$(MYSQL_LIBS)))
+comma          := ,
+LDFLAGS        += $(addprefix -Wl$(comma)-rpath$(comma),$(RPATH_DIRS))
 endif
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -34,16 +34,18 @@ relational database instead of flat `.scp` files.
 
 - MySQL Server **5.7** or newer (MariaDB **10.3**+ works as well) with InnoDB
   and `utf8mb4` enabled.
-- MySQL Connector/C (libmysqlclient) **5.7**+ or an equivalent MariaDB client
-  library available during compilation. The repository vendors the header files
-  and documentation of Oracle's MySQL Connector/C **6.1.11** under
-  `third_party/mysql-connector-c-6.1.11-win32` so the project has a local copy
-  of `mysql.h` and friends, but you must supply the import libraries/DLL
-  yourself.
-- When building with Visual Studio set the environment variables
-  `MYSQL_INCLUDE_DIR` and `MYSQL_LIB_DIR`, or update the project properties, to
-  point at your connector installation. Those overrides take precedence over
-  the bundled headers.
+- MariaDB Connector/C **3.3.8** (or any compatible client library). Run
+  `scripts\fetch_mariadb_connector.bat` after cloning the repository to download
+  the official Windows and Linux connector archives into `third_party/`. The
+  legacy Oracle MySQL Connector/C **6.1.11** headers remain available under
+  `third_party/mysql-connector-c-6.1.11-win32` for projects that still rely on
+  them. You can still override the include/library directories with the
+  `MYSQL_INCLUDE_DIR` and `MYSQL_LIB_DIR` environment variables if you would
+  rather target a system-wide installation.
+- When building with Visual Studio you can keep the defaults that point at the
+  bundled MariaDB connector or set the `MYSQL_INCLUDE_DIR` and
+  `MYSQL_LIB_DIR` environment variables to target a custom installation. Those
+  overrides take precedence over the bundled packages.
 
 ### New configuration keys (`spheredef.ini aka sphere.ini`)
 

--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -1,15 +1,20 @@
 # Third-party components
 
-The repository vendors the header files and documentation of Oracle's
-**MySQL Connector/C 6.1.11** under
-`third_party/mysql-connector-c-6.1.11-win32`. This keeps the public MySQL C API
-headers (`mysql.h`, `mysql_com.h`, etc.) in-tree together with the GPLv2 license
-and MySQL FOSS License Exception. Pre-built import libraries and DLLs are not
-included; obtain them from your preferred MySQL/MariaDB Connector/C installation
-and make them available to the linker/runtime via `MYSQL_LIB_DIR` or the project
-settings.
+SphereServer relies on the MariaDB/MySQL client libraries for its optional
+database backend. The repository keeps the legacy Oracle headers checked in for
+compatibility and ships a helper script that downloads the current MariaDB
+packages on demand:
 
-If you prefer a different version of the MySQL or MariaDB C client library you
-can override the include/library search paths by setting the
-`MYSQL_INCLUDE_DIR` and `MYSQL_LIB_DIR` environment variables before compiling,
-or by editing the project configuration directly.
+* **MariaDB Connector/C 3.3.8** (LGPL 2.1) can be fetched with
+  `scripts\fetch_mariadb_connector.bat`. The script downloads the official
+  Windows MSI and Ubuntu tarball, extracts them into `third_party/` and keeps the
+  directories out of Git via `.gitignore`. Run it whenever you need to refresh
+  the vendor drop. PowerShell 5+, `msiexec` and the `tar` utility available on
+  modern Windows installations are required.
+* **MySQL Connector/C 6.1.11** (GPLv2 + FOSS License Exception) remains checked
+  in under `third_party/mysql-connector-c-6.1.11-win32` for projects that still
+  rely on the older headers/import libraries.
+
+If you prefer a system-wide installation you can override the include and
+library search paths using the `MYSQL_INCLUDE_DIR` and `MYSQL_LIB_DIR`
+environment variables or by editing the IDE project settings.

--- a/scripts/fetch_mariadb_connector.bat
+++ b/scripts/fetch_mariadb_connector.bat
@@ -1,0 +1,126 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem Determine repository root (resolve ".." relative to this script)
+for %%I in ("%~dp0..") do set "REPO_ROOT=%%~fI"
+set "THIRD_PARTY=%REPO_ROOT%\third_party"
+set "DOWNLOADS=%THIRD_PARTY%\_downloads"
+set "WIN_TARGET=%THIRD_PARTY%\mariadb-connector-c-3.3.8-win32"
+set "LINUX_TARGET=%THIRD_PARTY%\mariadb-connector-c-3.3.8-linux"
+set "WIN_MSI=%DOWNLOADS%\mariadb-connector-c-3.3.8-win32.msi"
+set "LINUX_TARBALL=%DOWNLOADS%\mariadb-connector-c-3.3.8-ubuntu-jammy-amd64.tar.gz"
+set "WIN_URL=https://downloads.mariadb.com/Connectors/c/connector-c-3.3.8/mariadb-connector-c-3.3.8-win32.msi"
+set "LINUX_URL=https://downloads.mariadb.com/Connectors/c/connector-c-3.3.8/mariadb-connector-c-3.3.8-ubuntu-jammy-amd64.tar.gz"
+
+echo Preparing third_party directory under %REPO_ROOT%
+if not exist "%THIRD_PARTY%" (
+    mkdir "%THIRD_PARTY%" || goto :fail
+)
+if not exist "%DOWNLOADS%" (
+    mkdir "%DOWNLOADS%" || goto :fail
+)
+
+call :install_win
+if errorlevel 1 goto :fail
+
+call :install_linux
+if errorlevel 1 goto :fail
+
+echo.
+echo MariaDB Connector/C packages installed under %THIRD_PARTY%.
+exit /b 0
+
+:install_win
+if exist "%WIN_TARGET%\include\mysql.h" (
+    echo [win32] MariaDB Connector/C already present, skipping download.
+    goto :eof
+)
+
+echo [win32] Downloading %WIN_URL%
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$outFile = $env:WIN_MSI; if ([string]::IsNullOrWhiteSpace($outFile)) { throw 'WIN_MSI environment variable is empty.' } if (Test-Path -LiteralPath $outFile) { return }; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri $env:WIN_URL -OutFile $outFile -UseBasicParsing"
+if errorlevel 1 (
+    echo [win32] Failed to download package.
+    exit /b 1
+)
+
+set "WIN_TEMP=%DOWNLOADS%\win32"
+if exist "%WIN_TEMP%" rd /s /q "%WIN_TEMP%"
+mkdir "%WIN_TEMP%" || exit /b 1
+
+echo [win32] Extracting MSI payload...
+msiexec /a "%WIN_MSI%" TARGETDIR="%WIN_TEMP%" /qn
+if errorlevel 1 (
+    echo [win32] msiexec returned an error. Ensure Windows Installer is available and try again.
+    exit /b 1
+)
+
+set "WIN_PAYLOAD="
+for /f "usebackq delims=" %%I in (`powershell -NoProfile -Command "Get-ChildItem -Directory -Recurse -LiteralPath '%WIN_TEMP%' | Where-Object { Test-Path ([IO.Path]::Combine($_.FullName, 'include', 'mysql.h')) -and (Test-Path ([IO.Path]::Combine($_.FullName, 'lib', 'libmariadb.lib')) -or Test-Path ([IO.Path]::Combine($_.FullName, 'lib', 'mariadb', 'libmariadb.lib'))) } | Select-Object -First 1 -ExpandProperty FullName"`) do set "WIN_PAYLOAD=%%I"
+if not defined WIN_PAYLOAD (
+    echo [win32] Unable to locate extracted connector files.
+    exit /b 1
+)
+
+if exist "%WIN_TARGET%" rd /s /q "%WIN_TARGET%"
+mkdir "%WIN_TARGET%" || exit /b 1
+
+echo [win32] Copying files into %WIN_TARGET%
+robocopy "%WIN_PAYLOAD%" "%WIN_TARGET%" /E /NFL /NDL /NJH /NJS /NC /NS >nul
+set "ROBOCODE=%ERRORLEVEL%"
+if %ROBOCODE% GEQ 8 (
+    echo [win32] robocopy failed with code %ROBOCODE%.
+    exit /b 1
+)
+
+echo [win32] Connector installed successfully.
+exit /b 0
+
+:install_linux
+if exist "%LINUX_TARGET%\include\mysql.h" (
+    echo [linux] MariaDB Connector/C already present, skipping download.
+    goto :eof
+)
+
+echo [linux] Downloading %LINUX_URL%
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$outFile = $env:LINUX_TARBALL; if ([string]::IsNullOrWhiteSpace($outFile)) { throw 'LINUX_TARBALL environment variable is empty.' } if (Test-Path -LiteralPath $outFile) { return }; $ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri $env:LINUX_URL -OutFile $outFile -UseBasicParsing"
+if errorlevel 1 (
+    echo [linux] Failed to download package.
+    exit /b 1
+)
+
+set "LINUX_TEMP=%DOWNLOADS%\linux"
+if exist "%LINUX_TEMP%" rd /s /q "%LINUX_TEMP%"
+mkdir "%LINUX_TEMP%" || exit /b 1
+
+echo [linux] Extracting tarball...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "param([string]$Archive,[string]$Destination) if (-not (Get-Command tar -ErrorAction SilentlyContinue)) { Write-Error 'tar.exe was not found in PATH'; exit 1 } tar -xf $Archive -C $Destination" "%LINUX_TARBALL%" "%LINUX_TEMP%"
+if errorlevel 1 (
+    echo [linux] Failed to extract tarball. Install a tar utility (Windows 10+ ships one by default) and retry.
+    exit /b 1
+)
+
+set "LINUX_PAYLOAD="
+for /f "usebackq delims=" %%I in (`powershell -NoProfile -Command "Get-ChildItem -Directory -Recurse -LiteralPath '%LINUX_TEMP%' | Where-Object { Test-Path ([IO.Path]::Combine($_.FullName, 'include', 'mariadb', 'mysql.h')) -or Test-Path ([IO.Path]::Combine($_.FullName, 'include', 'mysql', 'mysql.h')) -or Test-Path ([IO.Path]::Combine($_.FullName, 'include', 'mysql.h')) } | Select-Object -First 1 -ExpandProperty FullName"`) do set "LINUX_PAYLOAD=%%I"
+if not defined LINUX_PAYLOAD (
+    echo [linux] Unable to locate extracted connector files.
+    exit /b 1
+)
+
+if exist "%LINUX_TARGET%" rd /s /q "%LINUX_TARGET%"
+mkdir "%LINUX_TARGET%" || exit /b 1
+
+echo [linux] Copying files into %LINUX_TARGET%
+robocopy "%LINUX_PAYLOAD%" "%LINUX_TARGET%" /E /NFL /NDL /NJH /NJS /NC /NS >nul
+set "ROBOCODE=%ERRORLEVEL%"
+if %ROBOCODE% GEQ 8 (
+    echo [linux] robocopy failed with code %ROBOCODE%.
+    exit /b 1
+)
+
+echo [linux] Connector installed successfully.
+exit /b 0
+
+:fail
+echo.
+echo Dependency download failed. See messages above for details.
+exit /b 1


### PR DESCRIPTION
## Summary
- update the MariaDB connector fetch script to have PowerShell read the download paths from environment variables and fail fast when they are missing
- keep the download guard in PowerShell so retries skip already cached archives

## Testing
- make -C GraySvr -j2

------
https://chatgpt.com/codex/tasks/task_e_68cfe6b12ee0832cbe54ebc0f43313d3