### PR TITLE
Ensure stable MariaDB option strings

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <list>
 #include <new>
 #include <stdexcept>
 
@@ -325,7 +326,7 @@ public:
 
                 MYSQL * handle = RequireHandle( "mysql_options" );
 
-                m_StringOptions.push_back( value );
+                m_StringOptions.emplace_back( value );
                 const char * pszValue = m_StringOptions.back().c_str();
                 if ( mysql_options( handle, option, pszValue ) != 0 )
                 {
@@ -545,7 +546,7 @@ private:
         };
 
         std::unique_ptr<MYSQL, MysqlHandleDeleter> m_Handle;
-        std::vector<std::string> m_StringOptions;
+        std::list<std::string> m_StringOptions;
 };
 
 void LogMariaDbException( const MariaDbException & ex, LOGL_TYPE level )


### PR DESCRIPTION
## Summary
- switch the MariaDbConnection string option cache to std::list so stored C strings remain valid
- update SetStringOption to emplace values before acquiring their c_str pointer when applying options

## Testing
- not run (environment lacks the tooling to build or run the server)


------
https://chatgpt.com/codex/tasks/task_e_68d034a92140832cba225749eeca325b