### PR TITLE
Harden MySQL table prefix validation

### DIFF
--- a/GraySvr/CWorldStorageMySQL.cpp
+++ b/GraySvr/CWorldStorageMySQL.cpp
@@ -1,5 +1,6 @@
 #include "graysvr.h"
 #include "CWorldStorageMySQL.h"
+#include "CWorldStorageMySQLUtils.h"
 
 #ifdef max
 #undef max
@@ -123,25 +124,6 @@ bool GenerateTempScriptPath( std::string & outPath )
         catch ( const std::bad_alloc & )
         {
                 return false;
-        }
-
-        return true;
-}
-
-bool IsSafeMariaDbIdentifierToken( const std::string & token )
-{
-        if ( token.empty())
-        {
-                return false;
-        }
-
-        for ( char ch : token )
-        {
-                unsigned char uch = static_cast<unsigned char>( ch );
-                if (( uch != '_' ) && !std::isalnum( uch ))
-                {
-                        return false;
-                }
         }
 
         return true;
@@ -847,7 +829,32 @@ bool CWorldStorageMySQL::Connect( const CServerMySQLConfig & config )
                 return false;
         }
 
-        m_sTablePrefix = config.m_sTablePrefix;
+        std::string normalizedPrefix;
+        std::string prefixError;
+        const char * rawPrefix = config.m_sTablePrefix.IsEmpty() ? NULL : (const char *) config.m_sTablePrefix;
+        if ( !NormalizeMySQLTablePrefix( rawPrefix, normalizedPrefix, &prefixError ))
+        {
+                m_sTablePrefix.Empty();
+                if ( prefixError.empty())
+                {
+                        g_Log.Event( LOGM_INIT|LOGL_ERROR, "MySQL table prefix validation failed; aborting connection attempt." );
+                }
+                else
+                {
+                        g_Log.Event( LOGM_INIT|LOGL_ERROR, "%s Aborting MySQL connection attempt.", prefixError.c_str());
+                }
+                return false;
+        }
+
+        if ( normalizedPrefix.empty())
+        {
+                m_sTablePrefix.Empty();
+        }
+        else
+        {
+                m_sTablePrefix = normalizedPrefix.c_str();
+        }
+
         m_fAutoReconnect = config.m_fAutoReconnect;
         m_iReconnectTries = config.m_iReconnectTries;
         m_iReconnectDelay = config.m_iReconnectDelay;

--- a/GraySvr/CWorldStorageMySQLUtils.cpp
+++ b/GraySvr/CWorldStorageMySQLUtils.cpp
@@ -1,0 +1,102 @@
+#include "CWorldStorageMySQLUtils.h"
+
+#include <cctype>
+#include <cstdio>
+#include <string>
+
+namespace
+{
+        void TrimAsciiWhitespace( std::string & value )
+        {
+                const char * whitespace = " \t\n\r\f\v";
+                size_t begin = value.find_first_not_of( whitespace );
+                if ( begin == std::string::npos )
+                {
+                        value.clear();
+                        return;
+                }
+
+                size_t end = value.find_last_not_of( whitespace );
+                value = value.substr( begin, end - begin + 1 );
+        }
+
+        std::string SanitizeIdentifierForLogging( const std::string & token )
+        {
+                std::string sanitized;
+                sanitized.reserve( token.size());
+
+                for ( unsigned char ch : token )
+                {
+                        if ( ch >= 0x20 && ch <= 0x7e )
+                        {
+                                sanitized.push_back( static_cast<char>( ch ));
+                        }
+                        else
+                        {
+                                char buffer[5];
+                                std::snprintf( buffer, sizeof( buffer ), "\\x%02X", ch );
+                                sanitized.append( buffer );
+                        }
+                }
+
+                return sanitized;
+        }
+}
+
+bool IsSafeMariaDbIdentifierToken( const std::string & token )
+{
+        if ( token.empty())
+        {
+                return false;
+        }
+
+        for ( char ch : token )
+        {
+                const unsigned char uch = static_cast<unsigned char>( ch );
+                const bool isAsciiLetter = ( uch >= 'A' && uch <= 'Z' ) || ( uch >= 'a' && uch <= 'z' );
+                const bool isAsciiDigit = ( uch >= '0' && uch <= '9' );
+                if ( !isAsciiLetter && !isAsciiDigit && uch != '_' )
+                {
+                        return false;
+                }
+        }
+
+        return true;
+}
+
+bool NormalizeMySQLTablePrefix( const char * rawPrefix, std::string & normalizedPrefix, std::string * outErrorMessage )
+{
+        normalizedPrefix.clear();
+
+        std::string working = rawPrefix != nullptr ? std::string( rawPrefix ) : std::string();
+        TrimAsciiWhitespace( working );
+
+        normalizedPrefix = working;
+        if ( normalizedPrefix.empty())
+        {
+                if ( outErrorMessage != nullptr )
+                {
+                        outErrorMessage->clear();
+                }
+                return true;
+        }
+
+        if ( !IsSafeMariaDbIdentifierToken( normalizedPrefix ))
+        {
+                if ( outErrorMessage != nullptr )
+                {
+                        const std::string sanitized = SanitizeIdentifierForLogging( normalizedPrefix );
+                        *outErrorMessage = "MySQL table prefix '" + sanitized + "' contains invalid characters; only ASCII letters, digits, and '_' are allowed.";
+                }
+
+                normalizedPrefix.clear();
+                return false;
+        }
+
+        if ( outErrorMessage != nullptr )
+        {
+                outErrorMessage->clear();
+        }
+        return true;
+}
+

--- a/GraySvr/CWorldStorageMySQLUtils.h
+++ b/GraySvr/CWorldStorageMySQLUtils.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+// Returns true when the provided token is a safe MariaDB identifier consisting of
+// ASCII alphanumeric characters or '_'.
+bool IsSafeMariaDbIdentifierToken( const std::string & token );
+
+// Normalizes the configured table prefix by trimming ASCII whitespace and validating
+// the remaining bytes. The normalized prefix is returned in \a normalizedPrefix when
+// validation succeeds.
+//
+// When validation fails, the normalized prefix is cleared and an optional error
+// message describing the failure is written to \a outErrorMessage.
+bool NormalizeMySQLTablePrefix( const char * rawPrefix, std::string & normalizedPrefix, std::string * outErrorMessage = nullptr );
+

--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="cvendoritem.cpp" />
     <ClCompile Include="CWorld.cpp" />
     <ClCompile Include="CWorldStorageMySQL.cpp" />
+    <ClCompile Include="CWorldStorageMySQLUtils.cpp" />
     <ClCompile Include="CVarDefMap.cpp" />
     <ClCompile Include="cworldimport.cpp" />
     <ClCompile Include="cworldmap.cpp" />
@@ -221,6 +222,7 @@
     <ClInclude Include="..\common\grayproto.h" />
     <ClInclude Include="CParty.h" />
     <ClInclude Include="CWorldStorageMySQL.h" />
+    <ClInclude Include="CWorldStorageMySQLUtils.h" />
     <ClInclude Include="CVarDefMap.h" />
     <ClInclude Include="graysvr.h" />
   </ItemGroup>

--- a/tests/mysql_table_prefix_test.cpp
+++ b/tests/mysql_table_prefix_test.cpp
@@ -1,0 +1,54 @@
+#include "../GraySvr/CWorldStorageMySQLUtils.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace
+{
+        void ExpectTrue( bool condition, const std::string & message )
+        {
+                if ( !condition )
+                {
+                        std::cerr << message << std::endl;
+                        std::exit( 1 );
+                }
+        }
+
+        void ExpectFalse( bool condition, const std::string & message )
+        {
+                ExpectTrue( !condition, message );
+        }
+}
+
+int main()
+{
+        std::string normalized;
+        std::string errorMessage;
+
+        bool valid = NormalizeMySQLTablePrefix( "  valid_prefix  ", normalized, &errorMessage );
+        ExpectTrue( valid, "Expected ASCII prefix to validate successfully." );
+        ExpectTrue( errorMessage.empty(), "Valid prefix should not produce an error message." );
+        ExpectTrue( normalized == "valid_prefix", "Valid prefix should be trimmed before use." );
+
+        normalized.clear();
+        errorMessage.clear();
+        bool invalid = NormalizeMySQLTablePrefix( "préfixe", normalized, &errorMessage );
+        ExpectFalse( invalid, "Non-ASCII prefix must fail validation." );
+        ExpectTrue( normalized.empty(), "Normalized prefix should be cleared when validation fails." );
+        ExpectTrue( !errorMessage.empty(), "Validation failure must produce an error message." );
+        ExpectTrue( errorMessage.find( "invalid characters" ) != std::string::npos, "Error message should describe the invalid prefix." );
+        ExpectTrue( errorMessage.find( "ASCII letters, digits, and '_'" ) != std::string::npos, "Validation error should explain the allowed characters." );
+        ExpectTrue( errorMessage.find( "\\x" ) != std::string::npos, "Non-ASCII bytes should be escaped in the error message." );
+
+        normalized.clear();
+        errorMessage.clear();
+        bool highBitInvalid = NormalizeMySQLTablePrefix( "\xDD\xDD", normalized, &errorMessage );
+        ExpectFalse( highBitInvalid, "High-bit bytes must fail validation regardless of locale." );
+        ExpectTrue( normalized.empty(), "Normalized prefix should be cleared for high-bit bytes." );
+        ExpectTrue( !errorMessage.empty(), "High-bit validation failures must produce an error message." );
+        ExpectTrue( errorMessage.find( "\\xDD\\xDD" ) != std::string::npos, "Each invalid byte should be escaped in the error message." );
+
+        return 0;
+}
+


### PR DESCRIPTION
## Summary
- validate and normalize the configured MySQL table prefix before attempting to connect, logging a clear error and aborting when validation fails
- share MariaDB identifier validation helpers for reuse across the server with a locale-independent ASCII check
- extend the regression test to cover high-bit prefixes and ensure the validation error explains the allowed characters

## Testing
- g++ -std=c++17 -ICommon -IGraySvr tests/mysql_table_prefix_test.cpp GraySvr/CWorldStorageMySQLUtils.cpp -o tests/mysql_table_prefix_test
- tests/mysql_table_prefix_test

------
https://chatgpt.com/codex/tasks/task_e_68d03bcb7d50832ca446241247da3d72