### PR TITLE
Convert MySQL prefixes to UTF-8

### DIFF
--- a/tests/mysql_table_prefix_test.cpp
+++ b/tests/mysql_table_prefix_test.cpp
@@ -1,0 +1,61 @@
+#include "graysvr.h"
+#include "CWorldStorageMySQL.h"
+#include "mysql_stub.h"
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+int main()
+{
+        ResetMysqlQueryFlag();
+        g_Log.Clear();
+
+        CWorldStorageMySQL storage;
+        CServerMySQLConfig config;
+        config.m_fEnable = true;
+        std::string cp1251Prefix = "\xEC\xE8\xF0_"; // "мир_" in Windows-1251
+        cp1251Prefix += "data";
+        config.m_sTablePrefix = cp1251Prefix.c_str();
+
+        bool connected = storage.Connect( config );
+        if ( !connected )
+        {
+                std::cerr << "Connect failed when prefix required recoding" << std::endl;
+                return 1;
+        }
+
+        std::string expectedPrefix = "\xD0\xBC\xD0\xB8\xD1\x80_data"; // "мир_data" in UTF-8
+        std::string actualPrefix = (const char *) storage.GetTablePrefix();
+        if ( actualPrefix != expectedPrefix )
+        {
+                std::cerr << "Prefix was not converted to UTF-8 as expected" << std::endl;
+                std::cerr << "Actual bytes: ";
+                std::cerr << std::setfill( '0' );
+                for ( unsigned char ch : actualPrefix )
+                {
+                        std::cerr << std::hex << std::setw( 2 ) << static_cast<int>( ch ) << ' ';
+                }
+                std::cerr << std::setfill( ' ' ) << std::dec << std::endl;
+                return 1;
+        }
+
+        bool conversionLogged = false;
+        for ( const auto & entry : g_Log.Events())
+        {
+                if ( entry.m_message.find( "Normalized MySQL table prefix bytes" ) != std::string::npos )
+                {
+                        conversionLogged = true;
+                        break;
+                }
+        }
+
+        if ( !conversionLogged )
+        {
+                std::cerr << "Expected normalization log message was not emitted" << std::endl;
+                return 1;
+        }
+
+        return 0;
+}
+

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+#include <strings.h>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+inline char * my_strupr( char * value )
+{
+        if ( value == nullptr )
+        {
+                return nullptr;
+        }
+
+        for ( char * ch = value; *ch != '\0'; ++ch )
+        {
+                *ch = static_cast<char>( std::toupper( static_cast<unsigned char>( *ch )));
+        }
+        return value;
+}
+
+#define strcmpi strcasecmp
+#define strupr my_strupr
+#endif
+
+#include "cstring.h"
+
+constexpr WORD LOGM_INIT = 0x0100;
+constexpr WORD LOGM_SAVE = 0x0200;
+
+struct LogEventEntry
+{
+        WORD m_mask;
+        std::string m_message;
+};
+
+class CLog
+{
+public:
+        void Event( WORD mask, const char * fmt, ... )
+        {
+                va_list args;
+                va_start( args, fmt );
+
+                char buffer[1024];
+                int count = std::vsnprintf( buffer, sizeof( buffer ), fmt, args );
+                if ( count < 0 )
+                {
+                        buffer[0] = '\0';
+                }
+                va_end( args );
+
+                m_events.push_back( LogEventEntry{ mask, std::string( buffer ) } );
+        }
+
+        void Clear()
+        {
+                m_events.clear();
+        }
+
+        const std::vector<LogEventEntry> & Events() const
+        {
+                return m_events;
+        }
+
+private:
+        std::vector<LogEventEntry> m_events;
+};
+
+class CServer
+{
+public:
+        CServer() : m_loading( false ) {}
+
+        bool IsLoading() const
+        {
+                return m_loading;
+        }
+
+        void SetLoading( bool loading )
+        {
+                m_loading = loading;
+        }
+
+private:
+        bool m_loading;
+};
+
+struct CServerMySQLConfig
+{
+        bool m_fEnable;
+        CGString m_sHost;
+        int m_iPort;
+        CGString m_sDatabase;
+        CGString m_sUser;
+        CGString m_sPassword;
+        CGString m_sTablePrefix;
+        CGString m_sCharset;
+        bool m_fAutoReconnect;
+        int m_iReconnectTries;
+        int m_iReconnectDelay;
+
+        CServerMySQLConfig() :
+                m_fEnable( false ),
+                m_sHost( "localhost" ),
+                m_iPort( 3306 ),
+                m_fAutoReconnect( true ),
+                m_iReconnectTries( 3 ),
+                m_iReconnectDelay( 5 )
+        {
+                m_sDatabase.Empty();
+                m_sUser.Empty();
+                m_sPassword.Empty();
+                m_sTablePrefix.Empty();
+                m_sCharset = "utf8mb4";
+        }
+};
+
+enum StorageDirtyType : int
+{
+        StorageDirtyType_None = 0,
+        StorageDirtyType_Save,
+        StorageDirtyType_Delete,
+};
+
+extern CLog g_Log;
+extern CServer g_Serv;
+

--- a/tests/stubs/mysql/errmsg.h
+++ b/tests/stubs/mysql/errmsg.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define CR_OUT_OF_MEMORY 2000
+

--- a/tests/stubs/mysql/mysql.h
+++ b/tests/stubs/mysql/mysql.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct st_mysql
+{
+        int unused;
+} MYSQL;
+
+typedef struct st_mysql_res
+{
+        int unused;
+} MYSQL_RES;
+
+typedef char ** MYSQL_ROW;
+
+typedef struct st_mysql_charset_info
+{
+        unsigned int number;
+        const char * name;
+        const char * csname;
+        const char * collation;
+        unsigned int state;
+} MY_CHARSET_INFO;
+
+enum mysql_option
+{
+        MYSQL_OPT_RECONNECT,
+        MYSQL_SET_CHARSET_NAME,
+        MYSQL_INIT_COMMAND
+};
+
+unsigned int mysql_num_fields( MYSQL_RES * result );
+MYSQL_ROW mysql_fetch_row( MYSQL_RES * result );
+void mysql_free_result( MYSQL_RES * result );
+MYSQL * mysql_init( MYSQL * mysql );
+int mysql_options( MYSQL * mysql, enum mysql_option option, const void * arg );
+unsigned int mysql_errno( MYSQL * mysql );
+MYSQL * mysql_real_connect( MYSQL * mysql, const char * host, const char * user, const char * passwd, const char * db, unsigned int port, const char * unix_socket, unsigned long clientflag );
+int mysql_set_character_set( MYSQL * mysql, const char * csname );
+unsigned long mysql_real_escape_string( MYSQL * mysql, char * to, const char * from, unsigned long length );
+const char * mysql_character_set_name( MYSQL * mysql );
+void mysql_get_character_set_info( MYSQL * mysql, MY_CHARSET_INFO * charset );
+const char * mysql_error( MYSQL * mysql );
+int mysql_query( MYSQL * mysql, const char * query );
+unsigned int mysql_field_count( MYSQL * mysql );
+MYSQL_RES * mysql_store_result( MYSQL * mysql );
+void mysql_close( MYSQL * mysql );
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/tests/stubs/mysql/mysqld_error.h
+++ b/tests/stubs/mysql/mysqld_error.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/tests/stubs/mysql_stub.h
+++ b/tests/stubs/mysql_stub.h
@@ -1,0 +1,5 @@
+#pragma once
+
+bool WasMysqlQueryCalled();
+void ResetMysqlQueryFlag();
+

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -1,0 +1,125 @@
+#include "mysql_stub.h"
+#include "graysvr.h"
+
+#include <mysql/mysql.h>
+#include <cstring>
+#include <cstdlib>
+
+CLog g_Log;
+CServer g_Serv;
+
+namespace
+{
+        MYSQL g_stub_mysql;
+        MY_CHARSET_INFO g_stub_charset_info;
+        char g_error_message[256] = "stub";
+        unsigned long g_escape_written = 0;
+        bool g_query_called = false;
+}
+
+bool WasMysqlQueryCalled()
+{
+        return g_query_called;
+}
+
+void ResetMysqlQueryFlag()
+{
+        g_query_called = false;
+}
+
+void Assert_CheckFail( const char *, const char *, unsigned )
+{
+        std::abort();
+}
+
+extern "C"
+{
+        unsigned int mysql_num_fields( MYSQL_RES * )
+        {
+                return 0;
+        }
+
+        MYSQL_ROW mysql_fetch_row( MYSQL_RES * )
+        {
+                return nullptr;
+        }
+
+        void mysql_free_result( MYSQL_RES * )
+        {
+        }
+
+        MYSQL * mysql_init( MYSQL * )
+        {
+                std::memset( &g_stub_mysql, 0, sizeof( g_stub_mysql ));
+                return &g_stub_mysql;
+        }
+
+        int mysql_options( MYSQL *, enum mysql_option, const void * )
+        {
+                return 0;
+        }
+
+        unsigned int mysql_errno( MYSQL * )
+        {
+                return 0;
+        }
+
+        MYSQL * mysql_real_connect( MYSQL * mysql, const char *, const char *, const char *, const char *, unsigned int, const char *, unsigned long )
+        {
+                return mysql;
+        }
+
+        int mysql_set_character_set( MYSQL *, const char * )
+        {
+                return 0;
+        }
+
+        unsigned long mysql_real_escape_string( MYSQL *, char * to, const char * from, unsigned long length )
+        {
+                if ( to != nullptr && from != nullptr )
+                {
+                        std::memcpy( to, from, length );
+                        g_escape_written = length;
+                }
+                return length;
+        }
+
+        const char * mysql_character_set_name( MYSQL * )
+        {
+                return "utf8mb4";
+        }
+
+        void mysql_get_character_set_info( MYSQL *, MY_CHARSET_INFO * cs )
+        {
+                if ( cs != nullptr )
+                {
+                        std::memset( cs, 0, sizeof( *cs ));
+                }
+        }
+
+        const char * mysql_error( MYSQL * )
+        {
+                return g_error_message;
+        }
+
+        int mysql_query( MYSQL *, const char * )
+        {
+                g_query_called = true;
+                return 0;
+        }
+
+        unsigned int mysql_field_count( MYSQL * )
+        {
+                return 0;
+        }
+
+        MYSQL_RES * mysql_store_result( MYSQL * )
+        {
+                return nullptr;
+        }
+
+        void mysql_close( MYSQL * )
+        {
+        }
+}
+


### PR DESCRIPTION
## Summary
- add UTF-8 normalization helpers and a Windows-1251 conversion table so MySQL table prefixes are validated and hex-logged safely
- convert non-UTF8 prefixes before connecting, emitting the new normalization message instead of failing
- update mysql_table_prefix_test to expect successful conversion and logging for high-bit prefixes

## Testing
- g++ -std=c++17 -DUNIT_TEST -Itests/stubs -ICommon -IGraySvr tests/mysql_table_prefix_test.cpp tests/stubs/mysql_stubs.cpp GraySvr/CWorldStorageMySQL.cpp Common/cstring.cpp -o tests/mysql_table_prefix_test
- ./tests/mysql_table_prefix_test


------
https://chatgpt.com/codex/tasks/task_e_68d05a8fb78c832c8b2a816cd347a012