### PR TITLE
Normalize MySQL table prefixes and extend tests

### DIFF
--- a/GraySvr/CWorldStorageMySQL.h
+++ b/GraySvr/CWorldStorageMySQL.h
@@ -228,6 +228,15 @@ public:
                 return m_sTablePrefix;
         }
 
+#ifdef UNIT_TEST
+        CGString DebugBuildSchemaVersionCreateQuery() const
+        {
+                return BuildSchemaVersionCreateQuery();
+        }
+
+        bool DebugExecuteQuery( const CGString & query );
+#endif
+
 private:
         friend class Transaction;
         friend class UniversalRecord;
@@ -267,6 +276,7 @@ private:
         const char * GetDefaultTableCharset() const;
         const char * GetDefaultTableCollation() const;
         CGString GetDefaultTableCollationSuffix() const;
+        CGString BuildSchemaVersionCreateQuery() const;
 
         bool SaveWorldObjectInternal( CObjBase * pObject );
         bool SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;

--- a/tests/mysql_table_prefix_test.cpp
+++ b/tests/mysql_table_prefix_test.cpp
@@ -5,46 +5,150 @@
 #include <iostream>
 #include <string>
 
+namespace
+{
+        std::string BuildRawCp1251Prefix()
+        {
+                std::string prefix = "\xEC\xE8\xF0_"; // "мир_" in Windows-1251
+                prefix += "data";
+                return prefix;
+        }
+
+        std::string ExpectedUtf8Prefix()
+        {
+                return std::string( u8"мир_data" );
+        }
+
+        bool RunNormalizationTest()
+        {
+                ResetMysqlQueryFlag();
+                g_Log.Clear();
+
+                CWorldStorageMySQL storage;
+                CServerMySQLConfig config;
+                config.m_fEnable = true;
+                std::string cp1251Prefix = BuildRawCp1251Prefix();
+                config.m_sTablePrefix = cp1251Prefix.c_str();
+
+                if ( !storage.Connect( config ))
+                {
+                        std::cerr << "Connect failed when using raw prefix value" << std::endl;
+                        return false;
+                }
+
+                const std::string expectedPrefix = ExpectedUtf8Prefix();
+                const std::string actualPrefix = (const char *) storage.GetTablePrefix();
+                if ( actualPrefix != expectedPrefix )
+                {
+                        std::cerr << "Prefix normalization did not produce the expected UTF-8 value" << std::endl;
+                        return false;
+                }
+
+                bool normalizationLogged = false;
+                bool reasonLogged = false;
+                for ( const auto & entry : g_Log.Events())
+                {
+                        if ( entry.m_message.find( "Normalized MySQL table prefix bytes" ) != std::string::npos )
+                        {
+                                normalizationLogged = true;
+                        }
+                        if ( entry.m_message.find( "Converted Windows-1251 bytes to UTF-8" ) != std::string::npos )
+                        {
+                                reasonLogged = true;
+                        }
+                }
+
+                if ( !normalizationLogged )
+                {
+                        std::cerr << "Normalization log message was not emitted" << std::endl;
+                        return false;
+                }
+
+                if ( !reasonLogged )
+                {
+                        std::cerr << "Normalization reason was not logged" << std::endl;
+                        return false;
+                }
+
+                return true;
+        }
+
+        bool RunSchemaCreationTest()
+        {
+                ResetMysqlQueryFlag();
+                g_Log.Clear();
+
+                CWorldStorageMySQL storage;
+                CServerMySQLConfig config;
+                config.m_fEnable = true;
+                std::string cp1251Prefix = BuildRawCp1251Prefix();
+                config.m_sTablePrefix = cp1251Prefix.c_str();
+
+                if ( !storage.Connect( config ))
+                {
+                        std::cerr << "Connect failed when using raw prefix value" << std::endl;
+                        return false;
+                }
+
+                ResetMysqlQueryFlag();
+
+                CGString createQueryCg = storage.DebugBuildSchemaVersionCreateQuery();
+                std::string createQuery = (const char *) createQueryCg;
+
+                if ( !storage.DebugExecuteQuery( createQueryCg ))
+                {
+                        std::cerr << "Executing schema creation query failed" << std::endl;
+                        return false;
+                }
+
+                if ( !WasMysqlQueryCalled())
+                {
+                        std::cerr << "No MySQL queries were executed during schema creation" << std::endl;
+                        return false;
+                }
+
+                const auto & queries = GetExecutedMysqlQueries();
+                const std::string expectedTableName = ExpectedUtf8Prefix() + "schema_version";
+
+                bool foundTableName = false;
+                for ( const auto & query : queries )
+                {
+                        if ( query.find( "CREATE TABLE IF NOT EXISTS`" ) != std::string::npos ||
+                                query.find( "CREATE TABLE IF NOT EXISTS `" ) != std::string::npos )
+                        {
+                                if ( query.find( expectedTableName ) != std::string::npos )
+                                {
+                                        foundTableName = true;
+                                        break;
+                                }
+                        }
+                }
+
+                if ( createQuery.find( expectedTableName ) == std::string::npos )
+                {
+                        std::cerr << "Normalized table name was not present in constructed schema query" << std::endl;
+                        return false;
+                }
+
+                if ( !foundTableName )
+                {
+                        std::cerr << "Normalized table name was not used in CREATE TABLE statement" << std::endl;
+                        return false;
+                }
+
+                return true;
+        }
+}
+
 int main()
 {
-        ResetMysqlQueryFlag();
-        g_Log.Clear();
-
-        CWorldStorageMySQL storage;
-        CServerMySQLConfig config;
-        config.m_fEnable = true;
-        std::string cp1251Prefix = "\xEC\xE8\xF0_"; // "мир_" in Windows-1251
-        cp1251Prefix += "data";
-        config.m_sTablePrefix = cp1251Prefix.c_str();
-
-        bool connected = storage.Connect( config );
-        if ( !connected )
+        if ( !RunNormalizationTest())
         {
-                std::cerr << "Connect failed when using raw prefix value" << std::endl;
                 return 1;
         }
 
-        std::string expectedPrefix = cp1251Prefix;
-        std::string actualPrefix = (const char *) storage.GetTablePrefix();
-        if ( actualPrefix != expectedPrefix )
+        if ( !RunSchemaCreationTest())
         {
-                std::cerr << "Prefix was altered unexpectedly" << std::endl;
-                return 1;
-        }
-
-        bool normalizationLogged = false;
-        for ( const auto & entry : g_Log.Events())
-        {
-                if ( entry.m_message.find( "Normalized MySQL table prefix bytes" ) != std::string::npos )
-                {
-                        normalizationLogged = true;
-                        break;
-                }
-        }
-
-        if ( normalizationLogged )
-        {
-                std::cerr << "Normalization log message was unexpectedly emitted" << std::endl;
                 return 1;
         }
 

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -8,6 +8,7 @@
 #include <strings.h>
 #include <string>
 #include <vector>
+#include <netinet/in.h>
 
 #ifndef _WIN32
 inline char * my_strupr( char * value )
@@ -70,6 +71,21 @@ public:
 
 private:
         std::vector<LogEventEntry> m_events;
+};
+
+struct CRealTime
+{
+        int m_Year;
+        int m_Month;
+        int m_Day;
+        int m_Hour;
+        int m_Min;
+        int m_Sec;
+
+        bool IsValid() const
+        {
+                return true;
+        }
 };
 
 class CServer

--- a/tests/stubs/mysql_stub.h
+++ b/tests/stubs/mysql_stub.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 bool WasMysqlQueryCalled();
 void ResetMysqlQueryFlag();
+const std::vector<std::string> & GetExecutedMysqlQueries();
 

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -4,6 +4,8 @@
 #include <mysql/mysql.h>
 #include <cstring>
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 CLog g_Log;
 CServer g_Serv;
@@ -15,6 +17,7 @@ namespace
         char g_error_message[256] = "stub";
         unsigned long g_escape_written = 0;
         bool g_query_called = false;
+        std::vector<std::string> g_executed_queries;
 }
 
 bool WasMysqlQueryCalled()
@@ -25,6 +28,12 @@ bool WasMysqlQueryCalled()
 void ResetMysqlQueryFlag()
 {
         g_query_called = false;
+        g_executed_queries.clear();
+}
+
+const std::vector<std::string> & GetExecutedMysqlQueries()
+{
+        return g_executed_queries;
 }
 
 void Assert_CheckFail( const char *, const char *, unsigned )
@@ -102,9 +111,13 @@ extern "C"
                 return g_error_message;
         }
 
-        int mysql_query( MYSQL *, const char * )
+        int mysql_query( MYSQL *, const char * query )
         {
                 g_query_called = true;
+                if ( query != nullptr )
+                {
+                        g_executed_queries.emplace_back( query );
+                }
                 return 0;
         }
 


### PR DESCRIPTION
## Summary
- normalize the configured table prefix in `CWorldStorageMySQL::Connect`, logging any adjustments
- share helper utilities for schema prefix handling and expose unit-test hooks
- extend the MySQL prefix unit test to assert normalization behavior and schema query handling while enhancing test stubs

## Testing
- `g++ -std=c++17 -DUNIT_TEST -DUNIT_TEST_MYSQL_IMPLEMENTATION -Itests/stubs -Itests/stubs/mysql -ICommon -IGraySvr -IMariaDBConnector/include tests/mysql_table_prefix_test.cpp GraySvr/CWorldStorageMySQL.cpp Common/cstring.cpp Common/graycom.cpp tests/stubs/mysql_stubs.cpp -o mysql_table_prefix_test -pthread`
- `./mysql_table_prefix_test`


------
https://chatgpt.com/codex/tasks/task_e_68d07c123d38832ca455cb0a3112b6bf