### PR TITLE
Refactor MySQL storage to use prepared statements

### DIFF
--- a/Common/common.h
+++ b/Common/common.h
@@ -17,6 +17,8 @@
 
 // C standard types.
 
+#include <cstring>
+
 #ifndef _MAX_PATH			// stdlib.h ?
 #define _MAX_PATH   260 	// max. length of full pathname
 #endif

--- a/Common/cstring.h
+++ b/Common/cstring.h
@@ -77,15 +77,20 @@ public:
 		return( GetBuffer() );
 	}
     int SetLength( int iLen );
-	CGString()
-	{
-		Init();
-	}
-    CGString( const TCHAR * pStr )
-    {
-	    Init();
-    	Copy( pStr );
-    }
+        CGString()
+        {
+                Init();
+        }
+        CGString( const CGString & other )
+        {
+                Init();
+                Copy( other.GetPtr());
+        }
+        CGString( const TCHAR * pStr )
+        {
+                Init();
+                Copy( pStr );
+        }
 
     int GetLength() const
     {

--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -9,6 +9,14 @@
 #include <memory>
 #include <vector>
 
+namespace Storage
+{
+namespace Repository
+{
+        class PreparedStatementRepository;
+}
+}
+
 class CAccount;
 class CObjBase;
 class CRealTime;
@@ -171,6 +179,10 @@ public:
         };
 
         bool Start( const CServerMySQLConfig & config );
+        bool Connect( const CServerMySQLConfig & config )
+        {
+                return Start( config );
+        }
         void Stop();
         bool IsConnected() const;
         bool IsEnabled() const;
@@ -236,6 +248,7 @@ private:
         friend class Transaction;
         friend class UniversalRecord;
         friend class Storage::Schema::SchemaManager;
+        friend class Storage::Repository::PreparedStatementRepository;
 
         bool Query( const CGString & query, std::unique_ptr<Storage::IDatabaseResult> * pResult = NULL );
         bool ExecuteQuery( const CGString & query );
@@ -276,7 +289,6 @@ private:
         bool UpsertWorldObjectData( const CObjBase * pObject, const CGString & serialized );
         bool RefreshWorldObjectComponents( const CObjBase * pObject );
         bool RefreshWorldObjectRelations( const CObjBase * pObject );
-        void AppendVarDefComponents( const CGString & table, unsigned long long uid, const CVarDefMap * pMap, const TCHAR * pszComp, std::vector<UniversalRecord> & outRecords );
         CGString ComputeSerializedChecksum( const CGString & serialized ) const;
         bool ExecuteRecordsInsert( const std::vector<UniversalRecord> & records );
         bool ClearTable( const CGString & table );

--- a/GraySvr/Storage/MySql/ConnectionManager.cpp
+++ b/GraySvr/Storage/MySql/ConnectionManager.cpp
@@ -1,7 +1,11 @@
 #include "Storage/MySql/ConnectionManager.h"
 
 #include "Storage/MySql/MySqlLogging.h"
+#if defined(UNIT_TEST)
+#include "../../../tests/stubs/graysvr.h"
+#else
 #include "../../graysvr.h"
+#endif
 
 #include <algorithm>
 #include <chrono>
@@ -194,7 +198,7 @@ namespace MySql
                 }
                 else
                 {
-                        outDetails.m_TableCharset = activeInfo.m_sCharset;
+                        outDetails.m_TableCharset = activeInfo.m_Charset;
                 }
 
                 if ( !dbConfig.m_Collation.empty())
@@ -203,7 +207,7 @@ namespace MySql
                 }
                 else
                 {
-                        outDetails.m_TableCollation = activeInfo.m_sCollation;
+                        outDetails.m_TableCollation = activeInfo.m_Collation;
                 }
 
                 if ( !m_ConnectionPool )
@@ -243,9 +247,9 @@ namespace MySql
 
         MySqlConnection * ConnectionManager::GetActiveConnection( MySqlConnectionPool::ScopedConnection & scoped ) const
         {
-                if ( m_TransactionConnection && m_TransactionConnection->IsValid())
+                if ( m_TransactionConnection.IsValid())
                 {
-                        return &m_TransactionConnection->Get();
+                        return &m_TransactionConnection.Get();
                 }
 
                 if ( !m_ConnectionPool )

--- a/GraySvr/Storage/MySql/MySqlLogging.cpp
+++ b/GraySvr/Storage/MySql/MySqlLogging.cpp
@@ -1,4 +1,8 @@
+#if defined(UNIT_TEST)
+#include "../../../tests/stubs/graysvr.h"
+#else
 #include "../../graysvr.h"
+#endif
 #include "Storage/MySql/MySqlLogging.h"
 
 WORD GetMySQLErrorLogMask( LOGL_TYPE level )

--- a/tests/stubs/cexpression_stub.cpp
+++ b/tests/stubs/cexpression_stub.cpp
@@ -1,0 +1,42 @@
+#include "graycom.h"
+
+int CVarDefArray::FindValNum( int ) const
+{
+    return -1;
+}
+
+int CVarDefArray::FindValStr( const TCHAR * ) const
+{
+    return -1;
+}
+
+CExpression g_Exp;
+
+int CExpression::GetSingle( const TCHAR * & pArgs, bool fHexDef )
+{
+    if ( pArgs == NULL )
+    {
+        return 0;
+    }
+
+    char * endPtr = nullptr;
+    long value = strtol( pArgs, &endPtr, fHexDef ? 16 : 10 );
+    if ( endPtr == pArgs )
+    {
+        return 0;
+    }
+
+    pArgs = endPtr;
+    return static_cast<int>( value );
+}
+
+int CExpression::GetVal( const TCHAR * & pArgs, bool fHexDef )
+{
+    return GetSingle( pArgs, fHexDef );
+}
+
+bool CExpression::SetVarDef( const TCHAR *, const TCHAR * )
+{
+    return false;
+}
+

--- a/tests/stubs/mysql/mysql.h
+++ b/tests/stubs/mysql/mysql.h
@@ -18,6 +18,23 @@ typedef struct st_mysql_res
 
 typedef char ** MYSQL_ROW;
 
+typedef unsigned char my_bool;
+
+typedef struct st_mysql_stmt
+{
+        void * internal;
+} MYSQL_STMT;
+
+typedef struct st_mysql_bind
+{
+        unsigned int buffer_type;
+        void * buffer;
+        unsigned long buffer_length;
+        unsigned long * length;
+        my_bool * is_null;
+        my_bool is_unsigned;
+} MYSQL_BIND;
+
 typedef struct st_mysql_charset_info
 {
         unsigned int number;
@@ -27,8 +44,44 @@ typedef struct st_mysql_charset_info
         unsigned int state;
 } MY_CHARSET_INFO;
 
+enum enum_field_types
+{
+        MYSQL_TYPE_DECIMAL,
+        MYSQL_TYPE_TINY,
+        MYSQL_TYPE_SHORT,
+        MYSQL_TYPE_LONG,
+        MYSQL_TYPE_FLOAT,
+        MYSQL_TYPE_DOUBLE,
+        MYSQL_TYPE_NULL,
+        MYSQL_TYPE_TIMESTAMP,
+        MYSQL_TYPE_LONGLONG,
+        MYSQL_TYPE_INT24,
+        MYSQL_TYPE_DATE,
+        MYSQL_TYPE_TIME,
+        MYSQL_TYPE_DATETIME,
+        MYSQL_TYPE_YEAR,
+        MYSQL_TYPE_NEWDATE,
+        MYSQL_TYPE_VARCHAR,
+        MYSQL_TYPE_BIT,
+        MYSQL_TYPE_TIMESTAMP2,
+        MYSQL_TYPE_DATETIME2,
+        MYSQL_TYPE_TIME2,
+        MYSQL_TYPE_JSON,
+        MYSQL_TYPE_NEWDECIMAL,
+        MYSQL_TYPE_ENUM,
+        MYSQL_TYPE_SET,
+        MYSQL_TYPE_TINY_BLOB,
+        MYSQL_TYPE_MEDIUM_BLOB,
+        MYSQL_TYPE_LONG_BLOB,
+        MYSQL_TYPE_BLOB,
+        MYSQL_TYPE_VAR_STRING,
+        MYSQL_TYPE_STRING,
+        MYSQL_TYPE_GEOMETRY
+};
+
 enum mysql_option
 {
+        MYSQL_OPT_CONNECT_TIMEOUT,
         MYSQL_OPT_RECONNECT,
         MYSQL_SET_CHARSET_NAME,
         MYSQL_INIT_COMMAND
@@ -50,6 +103,16 @@ int mysql_query( MYSQL * mysql, const char * query );
 unsigned int mysql_field_count( MYSQL * mysql );
 MYSQL_RES * mysql_store_result( MYSQL * mysql );
 void mysql_close( MYSQL * mysql );
+
+MYSQL_STMT * mysql_stmt_init( MYSQL * mysql );
+int mysql_stmt_prepare( MYSQL_STMT * stmt, const char * query, unsigned long length );
+unsigned long mysql_stmt_param_count( MYSQL_STMT * stmt );
+int mysql_stmt_bind_param( MYSQL_STMT * stmt, MYSQL_BIND * bnd );
+int mysql_stmt_execute( MYSQL_STMT * stmt );
+int mysql_stmt_reset( MYSQL_STMT * stmt );
+int mysql_stmt_close( MYSQL_STMT * stmt );
+unsigned int mysql_stmt_errno( MYSQL_STMT * stmt );
+const char * mysql_stmt_error( MYSQL_STMT * stmt );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- introduce repository helpers in `MySqlStorageService` so world-object persistence now uses prepared statements for meta/data/components/relations
- extend the unit-test stubs (MySQL API and expression helpers) to support the new prepared-statement flow and fix unit-test-only includes in the connection manager/logging layers
- add a defensive copy constructor for `CGString`, include `<cstring>` in `common.h`, and bypass full schema migrations during unit tests to keep the new tests fast

## Testing
- `./mysql_table_prefix_test`


------
https://chatgpt.com/codex/tasks/task_e_68d12cda6f80832c906efc33e323b34d