### PR TITLE
Refactor dirty queue processing to RAII processor

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -2,7 +2,6 @@
 #define _MYSQL_STORAGE_SERVICE_H_
 
 #include "../Common/cstring.h"
-#include "Storage/DirtyQueue.h"
 #include "Storage/Schema/SchemaManager.h"
 #include "Storage/MySql/ConnectionManager.h"
 #include <functional>
@@ -11,6 +10,7 @@
 
 namespace Storage
 {
+        class DirtyQueueProcessor;
 namespace Repository
 {
         class PreparedStatementRepository;
@@ -36,6 +36,8 @@ class MySqlStorageService
 public:
         MySqlStorageService();
         ~MySqlStorageService();
+
+        using ObjectHandle = unsigned long long;
 
         class Transaction
         {
@@ -206,7 +208,7 @@ public:
         bool SaveWorldObjects( const std::vector<CObjBase*> & objects );
         bool DeleteWorldObject( const CObjBase * pObject );
         bool DeleteObject( const CObjBase * pObject );
-        void MarkObjectDirty( const CObjBase & object, StorageDirtyType type );
+        void ScheduleSave( ObjectHandle handle, StorageDirtyType type );
         bool ClearWorldData();
 
         bool SaveSector( const CSector & sector );
@@ -294,11 +296,9 @@ private:
         bool ClearTable( const CGString & table );
         CGString GetAccountNameById( unsigned int accountId );
 
-        bool ProcessDirtyObject( unsigned long long uid, StorageDirtyType type );
-
         Storage::MySql::ConnectionManager m_ConnectionManager;
         Storage::Schema::SchemaManager m_SchemaManager;
-        Storage::DirtyQueue m_DirtyQueue;
+        std::unique_ptr<Storage::DirtyQueueProcessor> m_DirtyProcessor;
         CGString m_sTablePrefix;
         CGString m_sDatabaseName;
         CGString m_sTableCharset;

--- a/GraySvr/Storage/DirtyQueue.cpp
+++ b/GraySvr/Storage/DirtyQueue.cpp
@@ -6,57 +6,17 @@
 
 namespace Storage
 {
-        DirtyQueue::DirtyQueue() :
-                m_Stop( false ),
-                m_Running( false )
-        {
-        }
+DirtyQueue::DirtyQueue()
+{
+}
 
-        DirtyQueue::~DirtyQueue()
-        {
-                Stop();
-        }
+DirtyQueue::~DirtyQueue()
+{
+}
 
-        void DirtyQueue::Start( ProcessCallback callback )
-        {
-                std::lock_guard<std::mutex> lock( m_Mutex );
-                if ( m_Running )
-                        return;
-                m_Callback = std::move( callback );
-                m_Stop = false;
-                m_Running = true;
-                m_Thread = std::thread( &DirtyQueue::WorkerLoop, this );
-        }
-
-        void DirtyQueue::Stop()
-        {
-                {
-                        std::lock_guard<std::mutex> lock( m_Mutex );
-                        if ( !m_Running )
-                                return;
-                        m_Stop = true;
-                }
-                m_Condition.notify_all();
-                if ( m_Thread.joinable())
-                {
-                        m_Thread.join();
-                }
-                {
-                        std::lock_guard<std::mutex> lock( m_Mutex );
-                        m_Running = false;
-                        m_Stop = false;
-                        m_Callback = ProcessCallback();
-                        m_Queue.clear();
-                        m_Pending.clear();
-                }
-        }
-
-        void DirtyQueue::Enqueue( unsigned long long uid, StorageDirtyType type )
-        {
+void DirtyQueue::Enqueue( unsigned long long uid, StorageDirtyType type )
+{
                 std::unique_lock<std::mutex> lock( m_Mutex );
-                if ( !m_Running || !m_Callback )
-                        return;
-
                 if ( type == StorageDirtyType_Delete )
                 {
                         m_Pending.erase( uid );
@@ -77,44 +37,38 @@ namespace Storage
                 {
                         it->second = StorageDirtyType_Save;
                 }
-        }
+}
 
-        void DirtyQueue::WorkerLoop()
-        {
+bool DirtyQueue::WaitForBatch( Batch & batch, std::stop_token stopToken )
+{
                 std::unique_lock<std::mutex> lock( m_Mutex );
-                while ( true )
+                const bool ready = m_Condition.wait( lock, stopToken, [this]()
                 {
-                        m_Condition.wait( lock, [this]()
-                        {
-                                return m_Stop || !m_Queue.empty();
-                        });
+                        return !m_Queue.empty();
+                });
 
-                        if ( m_Stop && m_Queue.empty())
-                                break;
-
-                        std::vector<std::pair<unsigned long long, StorageDirtyType>> batch;
-                        while ( !m_Queue.empty())
-                        {
-                                unsigned long long uid = m_Queue.front();
-                                m_Queue.pop_front();
-                                auto it = m_Pending.find( uid );
-                                if ( it == m_Pending.end())
-                                        continue;
-                                batch.emplace_back( uid, it->second );
-                                m_Pending.erase( it );
-                        }
-
-                        ProcessCallback callback = m_Callback;
-                        lock.unlock();
-                        for ( const auto & entry : batch )
-                        {
-                                if ( callback )
-                                {
-                                        callback( entry.first, entry.second );
-                                }
-                        }
-                        lock.lock();
+                if ( !ready && m_Queue.empty())
+                {
+                        return false;
                 }
-        }
+
+                CollectBatch( batch );
+                return true;
+}
+
+void DirtyQueue::CollectBatch( Batch & batch )
+{
+                batch.clear();
+                while ( !m_Queue.empty())
+                {
+                        unsigned long long uid = m_Queue.front();
+                        m_Queue.pop_front();
+                        auto it = m_Pending.find( uid );
+                        if ( it == m_Pending.end())
+                                continue;
+                        batch.emplace_back( uid, it->second );
+                        m_Pending.erase( it );
+                }
+}
 }
 

--- a/GraySvr/cbase.cpp
+++ b/GraySvr/cbase.cpp
@@ -428,13 +428,14 @@ void CObjBase::MarkDirty( StorageDirtyType type )
 	if ( pStorage == NULL || ! pStorage->IsEnabled())
 		return;
 
-	if ( type == StorageDirtyType_Delete )
-	{
-		m_fStorageNew = false;
-		m_fStorageDeleted = true;
-		pStorage->MarkObjectDirty( *this, StorageDirtyType_Delete );
-		return;
-	}
+        if ( type == StorageDirtyType_Delete )
+        {
+                m_fStorageNew = false;
+                m_fStorageDeleted = true;
+                const MySqlStorageService::ObjectHandle handle = static_cast<MySqlStorageService::ObjectHandle>((unsigned long long) (UINT) GetUID());
+                pStorage->ScheduleSave( handle, StorageDirtyType_Delete );
+                return;
+        }
 
 	if ( m_fStorageDeleted )
 		return;
@@ -446,7 +447,8 @@ void CObjBase::MarkDirty( StorageDirtyType type )
 		m_fStorageNew = false;
 	}
 
-	pStorage->MarkObjectDirty( *this, StorageDirtyType_Save );
+        const MySqlStorageService::ObjectHandle handle = static_cast<MySqlStorageService::ObjectHandle>((unsigned long long) (UINT) GetUID());
+        pStorage->ScheduleSave( handle, StorageDirtyType_Save );
 }
 
 void CObjBase::WriteTry( CScript & s )


### PR DESCRIPTION
## Summary
- Introduce a `DirtyQueueProcessor` that runs on `std::jthread`, batches queued work, and persists objects through the repository-backed save path with centralized logging.
- Update `DirtyQueue` to support stop-token aware batch extraction and track the processor on the storage service through a typed object handle.
- Replace the old `MarkObjectDirty` calls with the new `ScheduleSave` façade so world objects schedule saves without touching queue internals.

## Testing
- Not run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68d138a13af8832c93a7882d594f5dc7