### PR TITLE
Fix Windows MySQL includes

### DIFF
--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -72,7 +72,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\MariaDBConnector\include;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Midl>
       <TypeLibraryName>.\Release\GraySvr.tlb</TypeLibraryName>
@@ -91,7 +91,7 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Release\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\MariaDBConnector\lib;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>wsock32.lib;libmariadb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.10</Version>
     </Link>
@@ -118,7 +118,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExceptionHandling>Sync</ExceptionHandling>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\common;$(ProjectDir)..\MariaDBConnector\include;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\include;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\include;$(MYSQL_INCLUDE_DIR);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Midl>
       <TypeLibraryName>.\Debug\GraySvr.tlb</TypeLibraryName>
@@ -137,7 +137,7 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <OutputFile>.\Debug\GraySvr.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\MariaDBConnector\lib;$(ProjectDir)..\third_party\mariadb-connector-c-3.3.8-win32\lib;$(ProjectDir)..\third_party\mysql-connector-c-6.1.11-win32\lib;$(MYSQL_LIB_DIR);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>wsock32.lib;libmariadb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>0.12</Version>
     </Link>

--- a/GraySvr/Storage/Database.cpp
+++ b/GraySvr/Storage/Database.cpp
@@ -1,4 +1,4 @@
-#include "Storage/Database.h"
+#include "Database.h"
 
 #include <utility>
 

--- a/GraySvr/Storage/DirtyQueue.cpp
+++ b/GraySvr/Storage/DirtyQueue.cpp
@@ -1,4 +1,4 @@
-#include "Storage/DirtyQueue.h"
+#include "DirtyQueue.h"
 
 #include "../graysvr.h"
 

--- a/GraySvr/Storage/MySql/ConnectionManager.cpp
+++ b/GraySvr/Storage/MySql/ConnectionManager.cpp
@@ -1,6 +1,6 @@
-#include "Storage/MySql/ConnectionManager.h"
+#include "ConnectionManager.h"
 
-#include "Storage/MySql/MySqlLogging.h"
+#include "MySqlLogging.h"
 #if defined(UNIT_TEST)
 #include "../../../tests/stubs/graysvr.h"
 #else

--- a/GraySvr/Storage/MySql/ConnectionManager.h
+++ b/GraySvr/Storage/MySql/ConnectionManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Storage/Database.h"
-#include "Storage/MySql/MySqlConnection.h"
+#include "../Database.h"
+#include "MySqlConnection.h"
 
 #include <memory>
 #include <string>

--- a/GraySvr/Storage/MySql/MySqlConnection.cpp
+++ b/GraySvr/Storage/MySql/MySqlConnection.cpp
@@ -1,4 +1,4 @@
-#include "Storage/MySql/MySqlConnection.h"
+#include "MySqlConnection.h"
 
 #include <algorithm>
 #include <cctype>

--- a/GraySvr/Storage/MySql/MySqlConnection.h
+++ b/GraySvr/Storage/MySql/MySqlConnection.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Storage/Database.h"
+#include "../Database.h"
 
 #include <condition_variable>
 #include <memory>

--- a/GraySvr/Storage/MySql/MySqlLogging.cpp
+++ b/GraySvr/Storage/MySql/MySqlLogging.cpp
@@ -3,7 +3,7 @@
 #else
 #include "../../graysvr.h"
 #endif
-#include "Storage/MySql/MySqlLogging.h"
+#include "MySqlLogging.h"
 
 WORD GetMySQLErrorLogMask( LOGL_TYPE level )
 {

--- a/GraySvr/Storage/MySql/MySqlLogging.h
+++ b/GraySvr/Storage/MySql/MySqlLogging.h
@@ -5,7 +5,7 @@
 #else
 #include "../../../Common/common.h"
 #endif
-#include "Storage/Database.h"
+#include "../Database.h"
 
 WORD GetMySQLErrorLogMask( LOGL_TYPE level );
 void LogDatabaseError( const Storage::DatabaseError & ex, LOGL_TYPE level );

--- a/GraySvr/Storage/Schema/SchemaManager.cpp
+++ b/GraySvr/Storage/Schema/SchemaManager.cpp
@@ -3,7 +3,7 @@
 #else
 #include "../../../tests/stubs/graysvr.h"
 #endif
-#include "Storage/Schema/SchemaManager.h"
+#include "SchemaManager.h"
 
 #include "../../MySqlStorageService.h"
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ relational database instead of flat `.scp` files.
   the official Windows and Linux connector archives into `third_party/`. The
   legacy Oracle MySQL Connector/C **6.1.11** headers remain available under
   `third_party/mysql-connector-c-6.1.11-win32` for projects that still rely on
-  them. You can still override the include/library directories with the
+  them. Visual Studio builds also probe `MariaDBConnector/` at the repository
+  root so you can keep a copy of the connector tree under source control if you
+  prefer. You can still override the include/library directories with the
   `MYSQL_INCLUDE_DIR` and `MYSQL_LIB_DIR` environment variables if you would
   rather target a system-wide installation.
 - When building with Visual Studio you can keep the defaults that point at the

--- a/docs/third_party.md
+++ b/docs/third_party.md
@@ -10,7 +10,10 @@ packages on demand:
   Windows MSI and Ubuntu tarball, extracts them into `third_party/` and keeps the
   directories out of Git via `.gitignore`. Run it whenever you need to refresh
   the vendor drop. PowerShell 5+, `msiexec` and the `tar` utility available on
-  modern Windows installations are required.
+  modern Windows installations are required. If you prefer to keep a copy of the
+  headers and libraries under version control, drop them into
+  `MariaDBConnector/`; the Visual Studio project now looks there in addition to
+  `third_party/`.
 * **MySQL Connector/C 6.1.11** (GPLv2 + FOSS License Exception) remains checked
   in under `third_party/mysql-connector-c-6.1.11-win32` for projects that still
   rely on the older headers/import libraries.


### PR DESCRIPTION
## Summary
- update storage sources to use relative includes so they build without additional include paths
- allow the Visual Studio project to consume a MariaDB connector checked into `MariaDBConnector/`
- document the additional connector search location in the README and third-party notes

## Testing
- make -C tests
- ./storage_tests


------
https://chatgpt.com/codex/tasks/task_e_68d165c0bdc0832c85460c64e2227462