### PR TITLE
Fix MySQL storage shutdown compatibility

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -189,6 +189,20 @@ public:
         {
                 return Start( config );
         }
+        /**
+        * \brief Gracefully closes any active connections and background workers.
+        *
+        * The legacy storage code in the world loader still expects a Disconnect()
+        * method.  The modern implementation relies on Stop(), therefore we
+        * provide a small forwarding helper so both names remain valid.
+        */
+        void Disconnect()
+        {
+                Stop();
+        }
+        /**
+        * \brief Stops the storage subsystem and closes every active resource.
+        */
         void Stop();
         bool IsConnected() const;
         bool IsEnabled() const;

--- a/GraySvr/Storage/DirtyQueue.h
+++ b/GraySvr/Storage/DirtyQueue.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
-#include <stop_token>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -21,7 +21,23 @@ namespace Storage
                 ~DirtyQueue();
 
                 void Enqueue( unsigned long long uid, StorageDirtyType type );
-                bool WaitForBatch( Batch & batch, std::stop_token stopToken );
+                /**
+                * \brief Waits until there is work available or cancellation is requested.
+                *
+                * @param batch Destination container that will be filled with the
+                *        operations to be processed.
+                * @param stopRequested A flag that becomes true when the caller wants
+                *        to cancel the wait.  The method returns false when the flag is
+                *        set and no work is pending.
+                * @return True when \p batch contains work items, false when the wait
+                *         was cancelled before any new entry arrived.
+                */
+                bool WaitForBatch( Batch & batch, const std::atomic_bool & stopRequested );
+
+                /**
+                * \brief Wakes every waiter so they can observe a cancellation flag.
+                */
+                void NotifyAll();
 
         private:
                 void CollectBatch( Batch & batch );


### PR DESCRIPTION
## Summary
- provide a Disconnect() shim for MySqlStorageService to keep existing callers working
- replace usage of std::stop_token and std::jthread with an atomic-based cancellation mechanism for DirtyQueue
- add Windows-safe network includes and update unit tests for the new cancellation flag

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d177b29d18832c9c029ad28685aa37