### PR TITLE
Add storage schema and MySQL sources to GraySvr project

### DIFF
--- a/GraySvr/GraySvr.vcxproj
+++ b/GraySvr/GraySvr.vcxproj
@@ -199,7 +199,11 @@
     <ClCompile Include="cworldmap.cpp" />
     <ClCompile Include="graysvr.cpp" />
     <ClCompile Include="Storage\Database.cpp" />
+    <ClCompile Include="Storage\DirtyQueue.cpp" />
+    <ClCompile Include="Storage\MySql\ConnectionManager.cpp" />
     <ClCompile Include="Storage\MySql\MySqlConnection.cpp" />
+    <ClCompile Include="Storage\MySql\MySqlLogging.cpp" />
+    <ClCompile Include="Storage\Schema\SchemaManager.cpp" />
     <ClCompile Include="ntservice.cpp" />
     <ClCompile Include="ntwindow.cpp" />
   </ItemGroup>
@@ -223,6 +227,12 @@
     <ClInclude Include="..\common\grayproto.h" />
     <ClInclude Include="CParty.h" />
     <ClInclude Include="MySqlStorageService.h" />
+    <ClInclude Include="Storage\Database.h" />
+    <ClInclude Include="Storage\DirtyQueue.h" />
+    <ClInclude Include="Storage\MySql\ConnectionManager.h" />
+    <ClInclude Include="Storage\MySql\MySqlConnection.h" />
+    <ClInclude Include="Storage\MySql\MySqlLogging.h" />
+    <ClInclude Include="Storage\Schema\SchemaManager.h" />
     <ClInclude Include="CVarDefMap.h" />
     <ClInclude Include="graysvr.h" />
   </ItemGroup>

--- a/GraySvr/GraySvr.vcxproj.filters
+++ b/GraySvr/GraySvr.vcxproj.filters
@@ -165,7 +165,19 @@
     <ClCompile Include="Storage\Database.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Storage\DirtyQueue.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Storage\MySql\ConnectionManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Storage\MySql\MySqlConnection.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Storage\MySql\MySqlLogging.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Storage\Schema\SchemaManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ntservice.cpp">
@@ -227,7 +239,19 @@
     <ClInclude Include="Storage\Database.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Storage\DirtyQueue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Storage\MySql\ConnectionManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="Storage\MySql\MySqlConnection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Storage\MySql\MySqlLogging.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Storage\Schema\SchemaManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CVarDefMap.h">


### PR DESCRIPTION
## Summary
- include the storage schema manager, connection manager, MySQL logging, and dirty queue sources in the GraySvr project so they are compiled
- add the associated header files to the project for easier navigation in Visual Studio

## Testing
- not run (project file changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d179793c2c832cb435ac050efb67af