### PR TITLE
Fix world object relations schema

### DIFF
--- a/GraySvr/Storage/Schema/SchemaManager.cpp
+++ b/GraySvr/Storage/Schema/SchemaManager.cpp
@@ -433,8 +433,10 @@ bool SchemaManager::ApplyMigration_2_3( MySqlStorageService & storage )
                 "CREATE TABLE IF NOT EXISTS `%s` (\n"
                 "`parent_uid` BIGINT UNSIGNED NOT NULL,\n"
                 "`child_uid` BIGINT UNSIGNED NOT NULL,\n"
-                "`relation_type` VARCHAR(32) NOT NULL,\n"
-                "PRIMARY KEY (`parent_uid`, `child_uid`, `relation_type`),\n"
+                "`relation` VARCHAR(32) NOT NULL,\n"
+                "`sequence` INT NOT NULL DEFAULT 0,\n"
+                "PRIMARY KEY (`parent_uid`, `child_uid`, `relation`, `sequence`),\n"
+                "KEY `ix_world_relations_child` (`child_uid`),\n"
                 "FOREIGN KEY (`parent_uid`) REFERENCES `%s`(`uid`) ON DELETE CASCADE,\n"
                 "FOREIGN KEY (`child_uid`) REFERENCES `%s`(`uid`) ON DELETE CASCADE\n"
                 ") ENGINE=InnoDB DEFAULT CHARSET=%s%s;",


### PR DESCRIPTION
## Summary
- align the world object relations table schema with the storage service expectations
- add the sequence column and child index so inserts use the existing prepared statements without errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a72d1f90832cbe0f6fc1419c1622