### PR TITLE
Prevent saving and loading empty world object data

### DIFF
--- a/tests/storage_world_objects_test.cpp
+++ b/tests/storage_world_objects_test.cpp
@@ -132,11 +132,12 @@ TEST_CASE( TestSaveWorldObjectPersistsMetaAndData )
         {
                 throw std::runtime_error( "UID parameter for world object data was incorrect" );
         }
-        if ( dataStmt->parameters[1] != std::string() )
+        const std::string expectedData = "UID=16909060\n";
+        if ( dataStmt->parameters[1] != expectedData )
         {
-                throw std::runtime_error( "Serialized payload was expected to be empty in stub" );
+                throw std::runtime_error( "Serialized payload did not contain object data" );
         }
-        if ( dataStmt->parameters[2] != ComputeFnv1a64( std::string() ))
+        if ( dataStmt->parameters[2] != ComputeFnv1a64( expectedData ))
         {
                 throw std::runtime_error( "Checksum was not recorded for world object data" );
         }

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -455,8 +455,15 @@ public:
                 return m_BaseDefs;
         }
 
-        virtual void r_Write( CScript & )
+        virtual void r_Write( CScript & script )
         {
+                std::ofstream output( script.GetFilePath(), std::ios::app );
+                if ( !output.is_open())
+                {
+                        return;
+                }
+
+                output << "UID=" << m_UID << '\n';
         }
 
         virtual bool r_Load( CScript & )


### PR DESCRIPTION
## Summary
- skip world objects retrieved from MySQL that have empty serialized payloads
- abort persistence when serialization generates no data and log a descriptive error
- update stubs and unit tests to emit non-empty serialized data and assert the checksum

## Testing
- make -C tests
- ./tests/storage_tests

------
https://chatgpt.com/codex/tasks/task_e_68d70561b7bc832da58224b17a82e99e