### PR TITLE
Restore character account ownership when loading from MySQL

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -152,6 +152,9 @@ public:
                 unsigned long long m_uid;
                 bool m_fIsChar;
                 int m_iBaseId;
+                bool m_fHasAccountId;
+                unsigned int m_iAccountId;
+                CGString m_sAccountName;
                 CGString m_sSerialized;
         };
 


### PR DESCRIPTION
## Summary
- include account identifiers and names when loading world objects from storage
- ensure characters reclaimed from MySQL are reattached to their owning account if the serialized data left them unlinked
- add a regression test that exercises the new world object metadata surface

## Testing
- `make` (from `tests/`)
- `./storage_tests`


------
https://chatgpt.com/codex/tasks/task_e_68de7a6ace3c83279f576a150d307e3b