### PR TITLE
Expose MySqlStorageService::GetAccountNameById for world loading

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -254,6 +254,8 @@ public:
         bool LoadGMPages( std::vector<GMPageRecord> & pages );
         bool LoadServers( std::vector<ServerRecord> & servers );
 
+        CGString GetAccountNameById( unsigned int accountId );
+
         const CGString & GetTablePrefix() const
         {
                 return m_sTablePrefix;
@@ -318,7 +320,6 @@ private:
         CGString ComputeSerializedChecksum( const CGString & serialized ) const;
         bool ExecuteRecordsInsert( const std::vector<UniversalRecord> & records );
         bool ClearTable( const CGString & table );
-        CGString GetAccountNameById( unsigned int accountId );
 
         Storage::MySql::ConnectionManager m_ConnectionManager;
         Storage::Schema::SchemaManager m_SchemaManager;


### PR DESCRIPTION
## Summary
- make `MySqlStorageService::GetAccountNameById` a public API so callers outside the class can resolve account names while loading world objects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee1599ba48327a6760dce2acf7ee5