### PR TITLE
Ensure new accounts persist initialized state

### DIFF
--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -716,6 +716,7 @@ private:
 	PLEVEL_TYPE m_PrivLevel;
 	CGString m_sName;			// Name = no spaces. case independant.
 	CGString m_sPassword;
+	bool m_fStorageUpdatesEnabled;
 
 #define PRIVOLD_ADMIN		0x0001
 #define PRIVOLD_COUNS		0x0004


### PR DESCRIPTION
## Summary
- initialize account state before enabling storage updates so the first persistence attempt uses valid defaults
- guard RequestStorageUpdate during construction and add coverage that parses the INSERT statement to confirm zeroed counters for new accounts

## Testing
- `cd tests && make clean && make && ./storage_tests`


