### PR TITLE
Save GM pages to storage immediately after submission

### DIFF
--- a/GraySvr/CClient.cpp
+++ b/GraySvr/CClient.cpp
@@ -417,6 +417,18 @@ void CClient::Cmd_GM_Page( const TCHAR * pszReason ) // Help button (Calls GM Ca
 		pPage->SetReason( pszReason );	// Description of reason for call.
 	}
 	pPage->m_p = m_pChar->GetTopPoint();		// Origin Point of call.
+
+	if ( ! g_World.IsSaving())
+	{
+		MySqlStorageService * pStorage = g_World.Storage();
+		if ( pStorage != NULL && pStorage->IsEnabled())
+		{
+			if ( ! pStorage->SaveGMPage( *pPage ))
+			{
+				g_Log.Event( LOGM_SAVE|LOGL_WARN, "Failed to persist GM page for account '%s'.\n", pPage->GetName());
+			}
+		}
+	}
 }
 
 void CClient::ClearGMHandle()


### PR DESCRIPTION
## Summary
- persist GM pages to MySQL immediately when a GM page is created or updated
- guard against redundant writes during world saves and log a warning if the immediate save fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df08c83bd48327a4e85c099debe5f2