### PR TITLE
Handle already-saved characters during MySQL serialization

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -314,8 +314,15 @@ private:
 
         bool SaveWorldObjectInternal( CObjBase * pObject );
         bool SaveWorldObjectInternal( CObjBase * pObject, std::unordered_set<unsigned long long> & visited );
+        enum class SerializationResult
+        {
+                Failed = 0,
+                Skipped,
+                Success
+        };
+
         bool PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited );
-        bool SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
+        SerializationResult SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
         bool UpsertWorldObjectMeta( CObjBase * pObject, const CGString & serialized );
         bool UpsertWorldObjectData( const CObjBase * pObject, const CGString & serialized );
         bool RefreshWorldObjectComponents( const CObjBase * pObject );


### PR DESCRIPTION
## Summary
- add a serialization result enum so world object saves can distinguish failures from skips
- treat characters whose save parity already matches the world state as skipped instead of fatal when serializing to MySQL

## Testing
- not run

