### PR TITLE
Populate legacy world relation columns during saves

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -287,6 +287,26 @@ public:
         {
                 return HandleMissingWorldRelationColumn();
         }
+
+        const CGString & DebugGetWorldRelationColumnName() const
+        {
+                return m_sWorldRelationColumnName;
+        }
+
+        bool DebugHasWorldRelationSequenceColumn() const
+        {
+                return m_fWorldRelationHasSequenceColumn;
+        }
+
+        bool DebugShouldPopulateWorldRelationTypeColumn() const
+        {
+                return m_fWorldRelationPopulateTypeColumn;
+        }
+
+        bool DebugShouldPopulateWorldRelationRelationTypeColumn() const
+        {
+                return m_fWorldRelationPopulateRelationTypeColumn;
+        }
 #endif
 
 private:
@@ -356,6 +376,14 @@ private:
         {
                 return m_fWorldRelationHasSequenceColumn;
         }
+        bool ShouldPopulateWorldRelationTypeColumn() const
+        {
+                return m_fWorldRelationPopulateTypeColumn;
+        }
+        bool ShouldPopulateWorldRelationRelationTypeColumn() const
+        {
+                return m_fWorldRelationPopulateRelationTypeColumn;
+        }
         CGString ComputeSerializedChecksum( const CGString & serialized ) const;
         bool ExecuteRecordsInsert( const std::vector<UniversalRecord> & records );
         bool ClearTable( const CGString & table );
@@ -373,6 +401,8 @@ private:
         time_t m_tLastAccountSync;
         CGString m_sWorldRelationColumnName;
         bool m_fWorldRelationHasSequenceColumn;
+        bool m_fWorldRelationPopulateTypeColumn;
+        bool m_fWorldRelationPopulateRelationTypeColumn;
 };
 
 #endif // _MYSQL_STORAGE_SERVICE_H_


### PR DESCRIPTION
## Summary
- update world object relation persistence to bind values for legacy `type`/`relation_type` columns alongside the primary relation field
- extend schema detection to prefer `relation_type` when present and track additional legacy columns for population
- adjust unit tests to cover multiple relation column bindings and updated column detection logic

## Testing
- `cd tests && make` *(fails: depends on full server symbols such as g_Serv::m_iSavePeriod that are unavailable in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc2524c3c8327bf12a2defe4efb5a