### PR TITLE
Improve skipped character persistence and schema compatibility

### DIFF
--- a/tests/stubs/common_stub.h
+++ b/tests/stubs/common_stub.h
@@ -31,6 +31,10 @@
 #define COUNTOF(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
+#ifndef TICK_PER_SEC
+#define TICK_PER_SEC 1
+#endif
+
 enum LOGL_TYPE : unsigned short
 {
         LOGL_FATAL = 1,

--- a/tests/stubs/mysql/mysql.h
+++ b/tests/stubs/mysql/mysql.h
@@ -87,6 +87,10 @@ enum mysql_option
         MYSQL_INIT_COMMAND
 };
 
+#ifndef MYSQL_NO_DATA
+#define MYSQL_NO_DATA 100
+#endif
+
 unsigned int mysql_num_fields( MYSQL_RES * result );
 MYSQL_ROW mysql_fetch_row( MYSQL_RES * result );
 void mysql_free_result( MYSQL_RES * result );
@@ -110,6 +114,9 @@ unsigned long mysql_stmt_param_count( MYSQL_STMT * stmt );
 int mysql_stmt_bind_param( MYSQL_STMT * stmt, MYSQL_BIND * bnd );
 int mysql_stmt_execute( MYSQL_STMT * stmt );
 int mysql_stmt_reset( MYSQL_STMT * stmt );
+int mysql_stmt_store_result( MYSQL_STMT * stmt );
+int mysql_stmt_fetch( MYSQL_STMT * stmt );
+void mysql_stmt_free_result( MYSQL_STMT * stmt );
 int mysql_stmt_close( MYSQL_STMT * stmt );
 unsigned int mysql_stmt_errno( MYSQL_STMT * stmt );
 const char * mysql_stmt_error( MYSQL_STMT * stmt );

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -11,8 +11,13 @@
 #include <string>
 #include <vector>
 
+#ifndef MYSQL_NO_DATA
+#define MYSQL_NO_DATA 100
+#endif
+
 CLog g_Log;
 CServer g_Serv;
+WorldStub g_World;
 
 namespace
 {
@@ -39,6 +44,8 @@ namespace
                 unsigned int last_error = 0;
                 unsigned long param_count = 0;
                 std::vector<MYSQL_BIND> binds;
+                std::vector<std::vector<std::string>> result_rows;
+                size_t result_index = 0;
         };
 
         bool g_query_called = false;
@@ -536,6 +543,56 @@ extern "C"
                         }
                 }
                 return 0;
+        }
+
+        int mysql_stmt_store_result( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return 1;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                data->result_rows.clear();
+                data->result_index = 0;
+
+                if ( g_pending_results.empty())
+                {
+                        return 0;
+                }
+
+                data->result_rows = std::move( g_pending_results.front());
+                g_pending_results.pop_front();
+                return 0;
+        }
+
+        int mysql_stmt_fetch( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return MYSQL_NO_DATA;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                if ( data->result_index < data->result_rows.size())
+                {
+                        ++data->result_index;
+                        return 0;
+                }
+
+                return MYSQL_NO_DATA;
+        }
+
+        void mysql_stmt_free_result( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                data->result_rows.clear();
+                data->result_index = 0;
         }
 
         int mysql_stmt_close( MYSQL_STMT * stmt )


### PR DESCRIPTION
## Summary
- surface metadata existence check errors and refine the skipped-character retry so save parity is only restored after successful serialization
- require the sequence column when refreshing components and relations while bypassing the schema probe in unit tests for compatibility

## Testing
- make -C tests
- ./tests/storage_tests | sed -n '1,120p'


------
https://chatgpt.com/codex/tasks/task_e_68dfd07cc91483279fadcfeb791b7974