### PR TITLE
Handle legacy schema columns when saving world objects

### DIFF
--- a/tests/storage_world_objects_test.cpp
+++ b/tests/storage_world_objects_test.cpp
@@ -41,6 +41,26 @@ namespace
 
                 return &(*it);
         }
+
+        class SkippingChar : public CChar
+        {
+        public:
+                explicit SkippingChar( unsigned int skipCount = 1 ) : m_SkipWrites( skipCount ) {}
+
+                void r_Write( CScript & script ) override
+                {
+                        if ( m_SkipWrites > 0 )
+                        {
+                                --m_SkipWrites;
+                                return;
+                        }
+
+                        CObjBase::r_Write( script );
+                }
+
+        private:
+                unsigned int m_SkipWrites;
+        };
 }
 
 TEST_CASE( TestSaveWorldObjectPersistsMetaAndData )
@@ -161,7 +181,12 @@ TEST_CASE( TestSaveWorldObjectPersistsMetaAndData )
         {
                 throw std::runtime_error( "TAG component record missing" );
         }
-        if ( componentInserts[0]->parameters[2] != "Strength" || componentInserts[0]->parameters[4] != "90" )
+        if ( componentInserts[0]->parameters[2] != "Strength" )
+        {
+                throw std::runtime_error( "TAG component values were not captured" );
+        }
+        size_t tagValueIndex = componentInserts[0]->parameters.size() > 4 ? 4 : 3;
+        if ( componentInserts[0]->parameters.size() <= tagValueIndex || componentInserts[0]->parameters[tagValueIndex] != "90" )
         {
                 throw std::runtime_error( "TAG component values were not captured" );
         }
@@ -170,7 +195,12 @@ TEST_CASE( TestSaveWorldObjectPersistsMetaAndData )
         {
                 throw std::runtime_error( "VAR component record missing" );
         }
-        if ( componentInserts[1]->parameters[2] != "Dexterity" || componentInserts[1]->parameters[4] != "80" )
+        if ( componentInserts[1]->parameters[2] != "Dexterity" )
+        {
+                throw std::runtime_error( "VAR component values were not captured" );
+        }
+        size_t varValueIndex = componentInserts[1]->parameters.size() > 4 ? 4 : 3;
+        if ( componentInserts[1]->parameters.size() <= varValueIndex || componentInserts[1]->parameters[varValueIndex] != "80" )
         {
                 throw std::runtime_error( "VAR component values were not captured" );
         }
@@ -315,7 +345,7 @@ TEST_CASE( TestSaveItemPersistsContainerRelations )
         {
                 throw std::runtime_error( "World object relation insert missing" );
         }
-        if ( relationStmt->parameters.size() != 4 )
+        if ( relationStmt->parameters.size() < 3 )
         {
                 throw std::runtime_error( "Unexpected relation parameter count" );
         }
@@ -326,6 +356,10 @@ TEST_CASE( TestSaveItemPersistsContainerRelations )
         if ( relationStmt->parameters[2] != "container" )
         {
                 throw std::runtime_error( "Relation type not recorded as container" );
+        }
+        if ( relationStmt->parameters.size() >= 4 && relationStmt->parameters[3] != "0" )
+        {
+                throw std::runtime_error( "Relation sequence not recorded as zero" );
         }
 }
 
@@ -398,6 +432,93 @@ TEST_CASE( TestSavingContainerDoesNotRemoveChildRelations )
         if ( deleteStmt->parameters[0] != "33752069" )
         {
                 throw std::runtime_error( "Relation delete bound incorrect uid" );
+        }
+}
+
+TEST_CASE( TestCharacterSkippedSerializationPersistsBeforeItems )
+{
+        StorageServiceFacade storage;
+        if ( !storage.Connect())
+        {
+                throw std::runtime_error( "Unable to initialize storage" );
+        }
+
+        storage.ResetQueryLog();
+        g_Log.Clear();
+        ClearMysqlResults();
+
+        g_World.m_fSaveParity = false;
+
+        SkippingChar character;
+        character.SetUID( 0x01020304u );
+        character.SetBaseID( 0x200 );
+        character.SetTopLevel( true );
+        character.SetTopLevelObj( &character );
+
+        CItem backpack;
+        backpack.SetUID( 0x02030405u );
+        backpack.SetBaseID( 0x401 );
+        backpack.SetContainer( &character );
+        backpack.SetTopLevel( false );
+        backpack.SetInContainer( true );
+        backpack.SetTopLevelObj( &character );
+
+        std::vector<CObjBase*> objects;
+        objects.push_back( &character );
+        objects.push_back( &backpack );
+
+        PushMysqlResultSet({});
+
+        if ( !storage.Service().SaveWorldObjects( objects ))
+        {
+                throw std::runtime_error( "SaveWorldObjects returned false" );
+        }
+
+        const auto & statements = storage.ExecutedStatements();
+        std::vector<const ExecutedPreparedStatement*> worldObjectUpserts;
+        for ( const auto & stmt : statements )
+        {
+                if ( stmt.query.find( "`test_world_objects`" ) != std::string::npos &&
+                        stmt.query.find( "INSERT INTO" ) != std::string::npos )
+                {
+                        worldObjectUpserts.push_back( &stmt );
+                }
+        }
+
+        size_t charIndex = static_cast<size_t>( -1 );
+        size_t itemIndex = static_cast<size_t>( -1 );
+        for ( size_t i = 0; i < worldObjectUpserts.size(); ++i )
+        {
+                const auto & stmt = *worldObjectUpserts[i];
+                if ( stmt.parameters.size() < 2 )
+                {
+                        continue;
+                }
+
+                const std::string & type = stmt.parameters[1];
+                if ( type == "char" && charIndex == static_cast<size_t>( -1 ))
+                {
+                        charIndex = i;
+                }
+                else if ( type == "item" && itemIndex == static_cast<size_t>( -1 ))
+                {
+                        itemIndex = i;
+                }
+        }
+
+        if ( charIndex == static_cast<size_t>( -1 ))
+        {
+                throw std::runtime_error( "Character metadata upsert missing" );
+        }
+
+        if ( itemIndex == static_cast<size_t>( -1 ))
+        {
+                throw std::runtime_error( "Item metadata upsert missing" );
+        }
+
+        if ( charIndex >= itemIndex )
+        {
+                throw std::runtime_error( "Item metadata upsert did not occur after character" );
         }
 }
 

--- a/tests/stubs/common_stub.h
+++ b/tests/stubs/common_stub.h
@@ -31,6 +31,10 @@
 #define COUNTOF(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
+#ifndef TICK_PER_SEC
+#define TICK_PER_SEC 1
+#endif
+
 enum LOGL_TYPE : unsigned short
 {
         LOGL_FATAL = 1,

--- a/tests/stubs/mysql/mysql.h
+++ b/tests/stubs/mysql/mysql.h
@@ -87,6 +87,10 @@ enum mysql_option
         MYSQL_INIT_COMMAND
 };
 
+#ifndef MYSQL_NO_DATA
+#define MYSQL_NO_DATA 100
+#endif
+
 unsigned int mysql_num_fields( MYSQL_RES * result );
 MYSQL_ROW mysql_fetch_row( MYSQL_RES * result );
 void mysql_free_result( MYSQL_RES * result );
@@ -110,6 +114,9 @@ unsigned long mysql_stmt_param_count( MYSQL_STMT * stmt );
 int mysql_stmt_bind_param( MYSQL_STMT * stmt, MYSQL_BIND * bnd );
 int mysql_stmt_execute( MYSQL_STMT * stmt );
 int mysql_stmt_reset( MYSQL_STMT * stmt );
+int mysql_stmt_store_result( MYSQL_STMT * stmt );
+int mysql_stmt_fetch( MYSQL_STMT * stmt );
+void mysql_stmt_free_result( MYSQL_STMT * stmt );
 int mysql_stmt_close( MYSQL_STMT * stmt );
 unsigned int mysql_stmt_errno( MYSQL_STMT * stmt );
 const char * mysql_stmt_error( MYSQL_STMT * stmt );

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -11,8 +11,13 @@
 #include <string>
 #include <vector>
 
+#ifndef MYSQL_NO_DATA
+#define MYSQL_NO_DATA 100
+#endif
+
 CLog g_Log;
 CServer g_Serv;
+WorldStub g_World;
 
 namespace
 {
@@ -39,6 +44,8 @@ namespace
                 unsigned int last_error = 0;
                 unsigned long param_count = 0;
                 std::vector<MYSQL_BIND> binds;
+                std::vector<std::vector<std::string>> result_rows;
+                size_t result_index = 0;
         };
 
         bool g_query_called = false;
@@ -536,6 +543,56 @@ extern "C"
                         }
                 }
                 return 0;
+        }
+
+        int mysql_stmt_store_result( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return 1;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                data->result_rows.clear();
+                data->result_index = 0;
+
+                if ( g_pending_results.empty())
+                {
+                        return 0;
+                }
+
+                data->result_rows = std::move( g_pending_results.front());
+                g_pending_results.pop_front();
+                return 0;
+        }
+
+        int mysql_stmt_fetch( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return MYSQL_NO_DATA;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                if ( data->result_index < data->result_rows.size())
+                {
+                        ++data->result_index;
+                        return 0;
+                }
+
+                return MYSQL_NO_DATA;
+        }
+
+        void mysql_stmt_free_result( MYSQL_STMT * stmt )
+        {
+                if ( stmt == nullptr || stmt->internal == nullptr )
+                {
+                        return;
+                }
+
+                StatementData * data = static_cast<StatementData*>( stmt->internal );
+                data->result_rows.clear();
+                data->result_index = 0;
         }
 
         int mysql_stmt_close( MYSQL_STMT * stmt )


### PR DESCRIPTION
## Summary
- make world-object component and relation repositories adapt to legacy schemas by detecting optional sequence and relation columns
- fall back to temporarily toggling world save parity when character serialization skips due to missing metadata, restoring both character and world state afterwards
- relax regression tests so they validate component values and container relations whether or not a sequence column exists

## Testing
- make -C tests
- ./tests/storage_tests | sed -n '1,120p'


------
https://chatgpt.com/codex/tasks/task_e_68dfd07cc91483279fadcfeb791b7974