### PR TITLE
Ensure character saves persist contained items

### DIFF
--- a/GraySvr/MySqlStorageService.cpp
+++ b/GraySvr/MySqlStorageService.cpp
@@ -3178,18 +3178,39 @@ bool MySqlStorageService::SaveWorldObjectInternal( CObjBase * pObject, std::unor
                 pCurrent = pParent;
         }
 
+        auto shouldPersistContents = []( CObjBase * pCandidate ) -> bool
+        {
+                if ( pCandidate == NULL )
+                {
+                        return false;
+                }
+
+                if ( pCandidate->IsChar())
+                {
+                        return true;
+                }
+
+                if ( pCandidate->IsItem())
+                {
+                        const CContainer * pContainer = dynamic_cast<const CContainer *>( pCandidate );
+                        return ( pContainer != NULL );
+                }
+
+                return false;
+        };
+
         for ( auto it = ancestors.rbegin(); it != ancestors.rend(); ++it )
         {
-                if ( ! PersistWorldObject( *it, visited ))
+                if ( ! PersistWorldObject( *it, visited, false ))
                 {
                         return false;
                 }
         }
 
-        return PersistWorldObject( pObject, visited );
+        return PersistWorldObject( pObject, visited, shouldPersistContents( pObject ));
 }
 
-bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited )
+bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited, bool includeContents )
 {
         if ( pObject == NULL )
         {
@@ -3231,6 +3252,54 @@ bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered
                 {
                         LogPersistenceFailure( *pObject, LOGL_ERROR, "relation refresh", "RefreshWorldObjectRelations returned false" );
                         fResult = false;
+                }
+        }
+
+        if ( includeContents && fResult )
+        {
+                const CContainer * pContainer = dynamic_cast<const CContainer *>( pObject );
+                if ( pContainer != NULL )
+                {
+                        std::vector<CObjBase *> children;
+                        for ( CItem * pItem = pContainer->GetContentHead(); pItem != NULL; pItem = pItem->GetNext())
+                        {
+                                if ( pItem == NULL )
+                                {
+                                        continue;
+                                }
+
+                                const UINT uid = static_cast<UINT>( pItem->GetUID());
+                                if ( uid == 0 )
+                                {
+                                        continue;
+                                }
+
+                                children.push_back( pItem );
+                        }
+
+                        for ( CObjBase * pChild : children )
+                        {
+                                if ( pChild == NULL )
+                                {
+                                        continue;
+                                }
+
+                                bool childIncludeContents = false;
+                                if ( pChild->IsChar())
+                                {
+                                        childIncludeContents = true;
+                                }
+                                else if ( pChild->IsItem())
+                                {
+                                        const CContainer * pChildContainer = dynamic_cast<const CContainer *>( pChild );
+                                        childIncludeContents = ( pChildContainer != NULL );
+                                }
+
+                                if ( ! PersistWorldObject( pChild, visited, childIncludeContents ))
+                                {
+                                        fResult = false;
+                                }
+                        }
                 }
         }
 
@@ -3589,6 +3658,23 @@ bool MySqlStorageService::RefreshWorldObjectRelations( const CObjBase * pObject 
                                 record.m_Relation = pItem->IsEquipped() ? "equipped" : "container";
                                 record.m_Sequence = 0;
                                 records.push_back( std::move( record ));
+                        }
+
+                        const CObjBaseTemplate * pTopTemplate = pItem->GetTopLevelObj();
+                        const CObjBase * pTopObject = dynamic_cast<const CObjBase*>( pTopTemplate );
+                        const CChar * pTopChar = dynamic_cast<const CChar*>( pTopObject );
+                        if ( pTopChar != NULL && pTopObject != NULL )
+                        {
+                                const unsigned long long parentUid = (unsigned long long) (UINT) pTopChar->GetUID();
+                                if ( parentUid != 0 && parentUid != uid )
+                                {
+                                        Storage::Repository::WorldObjectRelationRecord ownerRecord;
+                                        ownerRecord.m_ParentUid = parentUid;
+                                        ownerRecord.m_ChildUid = uid;
+                                        ownerRecord.m_Relation = "owner";
+                                        ownerRecord.m_Sequence = 0;
+                                        records.push_back( std::move( ownerRecord ));
+                                }
                         }
                 }
         }

--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -321,7 +321,7 @@ private:
                 Success
         };
 
-        bool PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited );
+        bool PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited, bool includeContents );
         SerializationResult SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
         bool UpsertWorldObjectMeta( CObjBase * pObject, const CGString & serialized );
         bool UpsertWorldObjectData( const CObjBase * pObject, const CGString & serialized );

--- a/tests/storage_world_objects_test.cpp
+++ b/tests/storage_world_objects_test.cpp
@@ -39,8 +39,14 @@ namespace
                         return nullptr;
                 }
 
-                return &(*it);
-        }
+return &(*it);
+}
+
+        class StubItemContainer : public CItem, public CContainer
+        {
+        public:
+                StubItemContainer() = default;
+        };
 }
 
 TEST_CASE( TestSaveWorldObjectPersistsMetaAndData )
@@ -398,6 +404,194 @@ TEST_CASE( TestSavingContainerDoesNotRemoveChildRelations )
         if ( deleteStmt->parameters[0] != "33752069" )
         {
                 throw std::runtime_error( "Relation delete bound incorrect uid" );
+        }
+}
+
+TEST_CASE( TestSavingEquippedItemRecordsOwnerRelation )
+{
+        StorageServiceFacade storage;
+        if ( !storage.Connect())
+        {
+                throw std::runtime_error( "Unable to initialize storage" );
+        }
+
+        CChar character;
+        character.SetUID( 0x0000002au );
+        character.SetBaseID( 0x200 );
+        character.SetTopLevel( true );
+        character.SetTopPoint( CPointMap( 100, 100, 0 ));
+        character.SetTopLevelObj( &character );
+
+        if ( !storage.Service().SaveWorldObject( &character ))
+        {
+                throw std::runtime_error( "Failed to save owner character" );
+        }
+
+        storage.ResetQueryLog();
+
+        CItem item;
+        item.SetUID( 0x01000010u );
+        item.SetBaseID( 0x500 );
+        item.SetContainer( &character );
+        item.SetTopLevel( false );
+        item.SetTopLevelObj( &character );
+        item.SetEquipped( true );
+
+        if ( !storage.Service().SaveWorldObject( &item ))
+        {
+                throw std::runtime_error( "Failed to save equipped item" );
+        }
+
+        const auto & statements = storage.ExecutedStatements();
+        std::vector<std::string> relations;
+        for ( const auto & stmt : statements )
+        {
+                if ( stmt.query.find( "`test_world_object_relations`" ) == std::string::npos )
+                {
+                        continue;
+                }
+                if ( stmt.query.find( "INSERT INTO" ) == std::string::npos )
+                {
+                        continue;
+                }
+
+                if ( stmt.parameters.size() != 4 )
+                {
+                        throw std::runtime_error( "Unexpected relation parameter count for equipped item" );
+                }
+                if ( stmt.parameters[0] != "42" || stmt.parameters[1] != "16777232" )
+                {
+                        throw std::runtime_error( "Equipped item relation parent/child identifiers incorrect" );
+                }
+                relations.push_back( stmt.parameters[2] );
+        }
+
+        if ( relations.size() != 2 )
+        {
+                throw std::runtime_error( "Equipped item did not record both container and owner relations" );
+        }
+
+        std::sort( relations.begin(), relations.end());
+        if ( relations[0] != "equipped" || relations[1] != "owner" )
+        {
+                throw std::runtime_error( "Equipped item relations missing expected types" );
+        }
+}
+
+TEST_CASE( TestSavingCharacterPersistsContainedItems )
+{
+        StorageServiceFacade storage;
+        if ( !storage.Connect())
+        {
+                throw std::runtime_error( "Unable to initialize storage" );
+        }
+
+        storage.ResetQueryLog();
+        g_Log.Clear();
+        ClearMysqlResults();
+
+        CAccount account;
+        account.SetName( "hero_account" );
+
+        CPlayer player( &account );
+
+        CChar character;
+        character.SetUID( 0x0000002au );
+        character.SetBaseID( 0x200 );
+        character.SetName( "Hero" );
+        character.SetPlayer( &player );
+        character.SetTopLevel( true );
+        character.SetTopPoint( CPointMap( 150, 150, 0 ));
+        character.SetTopLevelObj( &character );
+
+        StubItemContainer backpack;
+        backpack.SetUID( 0x01000020u );
+        backpack.SetBaseID( 0x510 );
+        backpack.SetTopLevel( false );
+        backpack.SetTopLevelObj( &character );
+
+        character.AddContent( &backpack );
+
+        CItem potion;
+        potion.SetUID( 0x02000033u );
+        potion.SetBaseID( 0x0f0 );
+        potion.SetTopLevel( false );
+        potion.SetTopLevelObj( &character );
+
+        backpack.AddContent( &potion );
+
+        PushMysqlResultSet({ { "77" } });
+
+        if ( !storage.Service().SaveWorldObject( &character ))
+        {
+                throw std::runtime_error( "Failed to save character with contained items" );
+        }
+
+        const auto & statements = storage.ExecutedStatements();
+        std::vector<std::string> dataUids;
+        for ( const auto & stmt : statements )
+        {
+                if ( stmt.query.find( "`test_world_object_data`" ) == std::string::npos )
+                {
+                        continue;
+                }
+                if ( stmt.query.find( "REPLACE INTO" ) == std::string::npos )
+                {
+                        continue;
+                }
+                if ( stmt.parameters.size() < 2 )
+                {
+                        continue;
+                }
+
+                dataUids.push_back( stmt.parameters[0] );
+        }
+
+        if ( dataUids.size() != 3 )
+        {
+                throw std::runtime_error( "Expected character and inventory items to be persisted" );
+        }
+
+        std::sort( dataUids.begin(), dataUids.end());
+
+        std::vector<std::string> expectedUids = {
+                std::to_string( static_cast<unsigned long long>( character.GetUID() )),
+                std::to_string( static_cast<unsigned long long>( backpack.GetUID() )),
+                std::to_string( static_cast<unsigned long long>( potion.GetUID() ))
+        };
+
+        std::sort( expectedUids.begin(), expectedUids.end());
+
+        if ( dataUids != expectedUids )
+        {
+                throw std::runtime_error( "World object data did not include all contained items" );
+        }
+
+        size_t potionRelationInserts = 0;
+        for ( const auto & stmt : statements )
+        {
+                if ( stmt.query.find( "`test_world_object_relations`" ) == std::string::npos )
+                {
+                        continue;
+                }
+                if ( stmt.query.find( "INSERT INTO" ) == std::string::npos )
+                {
+                        continue;
+                }
+                if ( stmt.parameters.size() != 4 )
+                {
+                        continue;
+                }
+
+                if ( stmt.parameters[1] == std::to_string( static_cast<unsigned long long>( potion.GetUID() )))
+                {
+                        ++potionRelationInserts;
+                }
+        }
+
+        if ( potionRelationInserts < 2 )
+        {
+                throw std::runtime_error( "Contained item was missing expected relations" );
         }
 }
 

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -95,7 +95,7 @@ struct CRealTime
 class CServer
 {
 public:
-        CServer() : m_loading( false ) {}
+        CServer() : m_iSavePeriod( 0 ), m_sWorldBaseDir(), m_loading( false ) {}
 
         bool IsLoading() const
         {
@@ -106,6 +106,9 @@ public:
         {
                 m_loading = loading;
         }
+
+        int m_iSavePeriod;
+        CGString m_sWorldBaseDir;
 
 private:
         bool m_loading;
@@ -151,13 +154,41 @@ enum StorageDirtyType : int
 extern CLog g_Log;
 extern CServer g_Serv;
 
+class CWorld
+{
+public:
+        CWorld() : m_fSaveParity( false ) {}
+
+        bool m_fSaveParity;
+};
+
+extern CWorld g_World;
+
 constexpr unsigned int PRIV_BLOCKED = 0x1u;
 constexpr unsigned int PRIV_JAILED = 0x2u;
+
+constexpr unsigned int STATF_SaveParity = 0x20000000u;
 
 constexpr unsigned int OF_WRITE   = 0x01u;
 constexpr unsigned int OF_READ    = 0x02u;
 constexpr unsigned int OF_TEXT    = 0x04u;
 constexpr unsigned int OF_NONCRIT = 0x08u;
+
+constexpr int TICK_PER_SEC = 1;
+
+inline CGString GetMergedFileName( const CGString & base, const char * name )
+{
+        CGString result( base );
+        if ( !result.IsEmpty())
+        {
+                result += '/';
+        }
+        if ( name != nullptr )
+        {
+                result += name;
+        }
+        return result;
+}
 
 class CUID
 {
@@ -597,28 +628,10 @@ private:
         CAccount * m_pAccount;
 };
 
-class CChar : public CObjBase
-{
-public:
-        CChar() : m_pPlayer( nullptr ) {}
-
-        bool IsChar() const override
-        {
-                return true;
-        }
-
-        void SetPlayer( CPlayer * player )
-        {
-                m_pPlayer = player;
-        }
-
-        CPlayer * m_pPlayer;
-};
-
 class CItem : public CObjBase
 {
 public:
-        CItem() : m_Equipped( false ) {}
+        CItem() : m_Equipped( false ), m_Next( nullptr ) {}
 
         bool IsItem() const override
         {
@@ -635,8 +648,74 @@ public:
                 m_Equipped = equipped;
         }
 
+        CItem * GetNext() const
+        {
+                return m_Next;
+        }
+
+        void SetNext( CItem * next )
+        {
+                m_Next = next;
+        }
+
 private:
         bool m_Equipped;
+        CItem * m_Next;
+};
+
+class CContainer
+{
+public:
+        CContainer() : m_ContentHead( nullptr ) {}
+        virtual ~CContainer() = default;
+
+        CItem * GetContentHead() const
+        {
+                return m_ContentHead;
+        }
+
+        void AddContent( CItem * item )
+        {
+                if ( item == nullptr )
+                {
+                        return;
+                }
+
+                item->SetNext( m_ContentHead );
+                m_ContentHead = item;
+
+                if ( const CObjBase * owner = dynamic_cast<const CObjBase *>( this ))
+                {
+                        item->SetContainer( owner );
+                        item->SetInContainer( true );
+                }
+        }
+
+protected:
+        CItem * m_ContentHead;
+};
+
+class CChar : public CObjBase, public CContainer
+{
+public:
+        CChar() : m_pPlayer( nullptr ) {}
+
+        bool IsChar() const override
+        {
+                return true;
+        }
+
+        void SetPlayer( CPlayer * player )
+        {
+                m_pPlayer = player;
+        }
+
+        bool IsStat( unsigned int ) const
+        {
+                return false;
+        }
+
+        CPlayer * m_pPlayer;
 };
 
 class CSector {};

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -13,6 +13,7 @@
 
 CLog g_Log;
 CServer g_Serv;
+CWorld g_World;
 
 namespace
 {


### PR DESCRIPTION
## Summary
- cascade world object persistence so characters and other containers save their contents alongside relations
- extend the unit-test stubs to model containers and add coverage for saving characters with inventory
- cast container child UIDs to UINT before zero checks to avoid ambiguous equality overloads during persistence

## Testing
- make -C tests

------
https://chatgpt.com/codex/tasks/task_e_68dfe2ab555c8327a8640c9d69b78ba8