### PR TITLE
Handle nested sections when applying stored world data

### DIFF
--- a/GraySvr/MySqlStorageService.cpp
+++ b/GraySvr/MySqlStorageService.cpp
@@ -3337,9 +3337,84 @@ bool MySqlStorageService::ApplyWorldObjectData( CObjBase & object, const CGStrin
         }
 
         bool fResult = false;
-        if ( script.FindNextSection())
+        bool fLoadedRoot = false;
+        const std::string context = FormatWorldObjectContext( object );
+
+        while ( script.FindNextSection())
         {
-                fResult = object.r_Load( script );
+                if ( ! fLoadedRoot )
+                {
+                        fLoadedRoot = true;
+                        fResult = object.r_Load( script );
+                        if ( ! fResult )
+                        {
+                                LogPersistenceFailure( object, LOGL_ERROR, "deserialize", "r_Load failed for root section" );
+                                break;
+                        }
+                        continue;
+                }
+
+                if ( script.IsSectionType( "WORLDITEM" ))
+                {
+                        CItem * pItem = CItem::CreateScript((ITEMID_TYPE) script.GetArgHex());
+                        if ( pItem == NULL )
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to instantiate item section while applying data for %s.\n", context.c_str());
+                                fResult = false;
+                                break;
+                        }
+
+                        if ( ! pItem->r_Load( script ))
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to load WORLDITEM section while applying data for %s.\n", context.c_str());
+                                pItem->Delete();
+#ifdef UNIT_TEST
+                                delete pItem;
+#endif
+                                fResult = false;
+                                break;
+                        }
+
+                        continue;
+                }
+
+                if ( script.IsSectionType( "WORLDCHAR" ))
+                {
+                        CChar * pChar = CChar::CreateBasic((CREID_TYPE) script.GetArgHex());
+                        if ( pChar == NULL )
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to instantiate character section while applying data for %s.\n", context.c_str());
+                                fResult = false;
+                                break;
+                        }
+
+                        if ( ! pChar->r_Load( script ))
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to load WORLDCHAR section while applying data for %s.\n", context.c_str());
+                                pChar->Delete();
+#ifdef UNIT_TEST
+                                delete pChar;
+#endif
+                                fResult = false;
+                                break;
+                        }
+
+                        continue;
+                }
+
+                if ( script.IsSectionType( "EOF" ))
+                {
+                        continue;
+                }
+
+                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Unexpected section '%s' while applying data for %s.\n", script.GetSection(), context.c_str());
+                fResult = false;
+                break;
+        }
+
+        if ( ! fLoadedRoot )
+        {
+                fResult = false;
         }
 
         script.Close();

--- a/tests/storage_world_objects_test.cpp
+++ b/tests/storage_world_objects_test.cpp
@@ -240,6 +240,73 @@ TEST_CASE( TestSaveWorldObjectPersistsAccountWhenMissing )
         }
 }
 
+TEST_CASE( TestApplyWorldObjectDataRestoresNestedItems )
+{
+        StorageServiceFacade storage;
+        if ( !storage.Connect())
+        {
+                throw std::runtime_error( "Unable to initialize storage" );
+        }
+
+        CItem rootContainer;
+        rootContainer.SetUID( 0x01000000u );
+        rootContainer.SetBaseID( 0x2000 );
+        rootContainer.SetName( "RootContainer" );
+        rootContainer.SetTopLevel( true );
+        rootContainer.SetTopLevelObj( &rootContainer );
+
+        const char * serializedData =
+                "[WORLDITEM 0x2000]\n"
+                "UID=16777216\n"
+                "NAME=RootContainer\n"
+                "[WORLDITEM 0x2001]\n"
+                "UID=16777217\n"
+                "CONT=16777216\n"
+                "NAME=FirstItem\n"
+                "[WORLDITEM 0x2002]\n"
+                "UID=16777218\n"
+                "CONT=16777216\n"
+                "NAME=SecondItem\n";
+
+        CGString serialized( serializedData );
+
+        if ( !storage.Service().ApplyWorldObjectData( rootContainer, serialized ))
+        {
+                throw std::runtime_error( "ApplyWorldObjectData returned false" );
+        }
+
+        const auto & contents = rootContainer.GetContents();
+        if ( contents.size() != 2 )
+        {
+                throw std::runtime_error( "Unexpected number of items restored in container" );
+        }
+
+        if ( contents[0]->GetUID() != 0x01000001u || contents[1]->GetUID() != 0x01000002u )
+        {
+                throw std::runtime_error( "Restored item UIDs were incorrect" );
+        }
+
+        if ( contents[0]->GetContainer() != &rootContainer || contents[1]->GetContainer() != &rootContainer )
+        {
+                throw std::runtime_error( "Restored items were not linked to the container" );
+        }
+
+        if ( std::string( contents[0]->GetName()) != "FirstItem" )
+        {
+                throw std::runtime_error( "First restored item name mismatch" );
+        }
+
+        if ( std::string( contents[1]->GetName()) != "SecondItem" )
+        {
+                throw std::runtime_error( "Second restored item name mismatch" );
+        }
+
+        for ( CItem * item : contents )
+        {
+                delete item;
+        }
+}
+
 TEST_CASE( TestSaveItemPersistsContainerRelations )
 {
         StorageServiceFacade storage;

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -13,6 +13,7 @@
 
 CLog g_Log;
 CServer g_Serv;
+StubWorld g_World;
 
 namespace
 {


### PR DESCRIPTION
## Summary
- iterate every serialized section in ApplyWorldObjectData and instantiate referenced world items or characters with proper error handling
- extend the unit-test stubs to parse scripted sections, maintain object registries, and expose the factories used during deserialization
- add a regression test that round-trips a container with nested items through ApplyWorldObjectData to ensure contents are restored

## Testing
- make
- ./storage_tests

------
https://chatgpt.com/codex/tasks/task_e_68dff4c39b4483279589aeb7922d3a8c