### PR TITLE
Fix MySQL storage recursion signature and stubs

### DIFF
--- a/GraySvr/MySqlStorageService.cpp
+++ b/GraySvr/MySqlStorageService.cpp
@@ -3178,18 +3178,39 @@ bool MySqlStorageService::SaveWorldObjectInternal( CObjBase * pObject, std::unor
                 pCurrent = pParent;
         }
 
+        auto shouldPersistContents = []( CObjBase * pCandidate ) -> bool
+        {
+                if ( pCandidate == NULL )
+                {
+                        return false;
+                }
+
+                if ( pCandidate->IsChar())
+                {
+                        return true;
+                }
+
+                if ( pCandidate->IsItem())
+                {
+                        const CContainer * pContainer = dynamic_cast<const CContainer *>( pCandidate );
+                        return ( pContainer != NULL );
+                }
+
+                return false;
+        };
+
         for ( auto it = ancestors.rbegin(); it != ancestors.rend(); ++it )
         {
-                if ( ! PersistWorldObject( *it, visited ))
+                if ( ! PersistWorldObject( *it, visited, false ))
                 {
                         return false;
                 }
         }
 
-        return PersistWorldObject( pObject, visited );
+        return PersistWorldObject( pObject, visited, shouldPersistContents( pObject ));
 }
 
-bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited )
+bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited, bool includeContents )
 {
         if ( pObject == NULL )
         {
@@ -3231,6 +3252,54 @@ bool MySqlStorageService::PersistWorldObject( CObjBase * pObject, std::unordered
                 {
                         LogPersistenceFailure( *pObject, LOGL_ERROR, "relation refresh", "RefreshWorldObjectRelations returned false" );
                         fResult = false;
+                }
+        }
+
+        if ( includeContents && fResult )
+        {
+                const CContainer * pContainer = dynamic_cast<const CContainer *>( pObject );
+                if ( pContainer != NULL )
+                {
+                        std::vector<CObjBase *> children;
+                        for ( CItem * pItem = pContainer->GetContentHead(); pItem != NULL; pItem = pItem->GetNext())
+                        {
+                                if ( pItem == NULL )
+                                {
+                                        continue;
+                                }
+
+                                const UINT childUid = static_cast<UINT>( pItem->GetUID());
+                                if ( childUid == 0 )
+                                {
+                                        continue;
+                                }
+
+                                children.push_back( pItem );
+                        }
+
+                        for ( CObjBase * pChild : children )
+                        {
+                                if ( pChild == NULL )
+                                {
+                                        continue;
+                                }
+
+                                bool childIncludeContents = false;
+                                if ( pChild->IsChar())
+                                {
+                                        childIncludeContents = true;
+                                }
+                                else if ( pChild->IsItem())
+                                {
+                                        const CContainer * pChildContainer = dynamic_cast<const CContainer *>( pChild );
+                                        childIncludeContents = ( pChildContainer != NULL );
+                                }
+
+                                if ( ! PersistWorldObject( pChild, visited, childIncludeContents ))
+                                {
+                                        fResult = false;
+                                }
+                        }
                 }
         }
 
@@ -3337,9 +3406,84 @@ bool MySqlStorageService::ApplyWorldObjectData( CObjBase & object, const CGStrin
         }
 
         bool fResult = false;
-        if ( script.FindNextSection())
+        bool fLoadedRoot = false;
+        const std::string context = FormatWorldObjectContext( object );
+
+        while ( script.FindNextSection())
         {
-                fResult = object.r_Load( script );
+                if ( ! fLoadedRoot )
+                {
+                        fLoadedRoot = true;
+                        fResult = object.r_Load( script );
+                        if ( ! fResult )
+                        {
+                                LogPersistenceFailure( object, LOGL_ERROR, "deserialize", "r_Load failed for root section" );
+                                break;
+                        }
+                        continue;
+                }
+
+                if ( script.IsSectionType( "WORLDITEM" ))
+                {
+                        CItem * pItem = CItem::CreateScript((ITEMID_TYPE) script.GetArgHex());
+                        if ( pItem == NULL )
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to instantiate item section while applying data for %s.\n", context.c_str());
+                                fResult = false;
+                                break;
+                        }
+
+                        if ( ! pItem->r_Load( script ))
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to load WORLDITEM section while applying data for %s.\n", context.c_str());
+                                pItem->Delete();
+#ifdef UNIT_TEST
+                                delete pItem;
+#endif
+                                fResult = false;
+                                break;
+                        }
+
+                        continue;
+                }
+
+                if ( script.IsSectionType( "WORLDCHAR" ))
+                {
+                        CChar * pChar = CChar::CreateBasic((CREID_TYPE) script.GetArgHex());
+                        if ( pChar == NULL )
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to instantiate character section while applying data for %s.\n", context.c_str());
+                                fResult = false;
+                                break;
+                        }
+
+                        if ( ! pChar->r_Load( script ))
+                        {
+                                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Failed to load WORLDCHAR section while applying data for %s.\n", context.c_str());
+                                pChar->Delete();
+#ifdef UNIT_TEST
+                                delete pChar;
+#endif
+                                fResult = false;
+                                break;
+                        }
+
+                        continue;
+                }
+
+                if ( script.IsSectionType( "EOF" ))
+                {
+                        continue;
+                }
+
+                g_Log.Event( LOGM_SAVE | LOGL_ERROR, "Unexpected section '%s' while applying data for %s.\n", script.GetKey(), context.c_str());
+                fResult = false;
+                break;
+        }
+
+        if ( ! fLoadedRoot )
+        {
+                fResult = false;
         }
 
         script.Close();

--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -321,7 +321,7 @@ private:
                 Success
         };
 
-        bool PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited );
+        bool PersistWorldObject( CObjBase * pObject, std::unordered_set<unsigned long long> & visited, bool includeContents );
         SerializationResult SerializeWorldObject( CObjBase * pObject, CGString & outSerialized ) const;
         bool UpsertWorldObjectMeta( CObjBase * pObject, const CGString & serialized );
         bool UpsertWorldObjectData( const CObjBase * pObject, const CGString & serialized );

--- a/tests/storage_world_objects_test.cpp
+++ b/tests/storage_world_objects_test.cpp
@@ -240,6 +240,73 @@ TEST_CASE( TestSaveWorldObjectPersistsAccountWhenMissing )
         }
 }
 
+TEST_CASE( TestApplyWorldObjectDataRestoresNestedItems )
+{
+        StorageServiceFacade storage;
+        if ( !storage.Connect())
+        {
+                throw std::runtime_error( "Unable to initialize storage" );
+        }
+
+        CItem rootContainer;
+        rootContainer.SetUID( 0x01000000u );
+        rootContainer.SetBaseID( 0x2000 );
+        rootContainer.SetName( "RootContainer" );
+        rootContainer.SetTopLevel( true );
+        rootContainer.SetTopLevelObj( &rootContainer );
+
+        const char * serializedData =
+                "[WORLDITEM 0x2000]\n"
+                "UID=16777216\n"
+                "NAME=RootContainer\n"
+                "[WORLDITEM 0x2001]\n"
+                "UID=16777217\n"
+                "CONT=16777216\n"
+                "NAME=FirstItem\n"
+                "[WORLDITEM 0x2002]\n"
+                "UID=16777218\n"
+                "CONT=16777216\n"
+                "NAME=SecondItem\n";
+
+        CGString serialized( serializedData );
+
+        if ( !storage.Service().ApplyWorldObjectData( rootContainer, serialized ))
+        {
+                throw std::runtime_error( "ApplyWorldObjectData returned false" );
+        }
+
+        const auto & contents = rootContainer.GetContents();
+        if ( contents.size() != 2 )
+        {
+                throw std::runtime_error( "Unexpected number of items restored in container" );
+        }
+
+        if ( contents[0]->GetUID() != 0x01000001u || contents[1]->GetUID() != 0x01000002u )
+        {
+                throw std::runtime_error( "Restored item UIDs were incorrect" );
+        }
+
+        if ( contents[0]->GetContainer() != &rootContainer || contents[1]->GetContainer() != &rootContainer )
+        {
+                throw std::runtime_error( "Restored items were not linked to the container" );
+        }
+
+        if ( std::string( contents[0]->GetName()) != "FirstItem" )
+        {
+                throw std::runtime_error( "First restored item name mismatch" );
+        }
+
+        if ( std::string( contents[1]->GetName()) != "SecondItem" )
+        {
+                throw std::runtime_error( "Second restored item name mismatch" );
+        }
+
+        for ( CItem * item : contents )
+        {
+                delete item;
+        }
+}
+
 TEST_CASE( TestSaveItemPersistsContainerRelations )
 {
         StorageServiceFacade storage;

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -12,6 +12,9 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <algorithm>
+#include <unordered_map>
+#include <cstdlib>
 #include <netinet/in.h>
 
 #ifndef _WIN32
@@ -34,6 +37,73 @@ inline char * my_strupr( char * value )
 #endif
 
 #include "common_stub.h"
+
+using ITEMID_TYPE = unsigned int;
+using CREID_TYPE = unsigned int;
+
+class CObjBase;
+class CItem;
+
+constexpr int TICK_PER_SEC = 1;
+constexpr unsigned int STATF_SaveParity = 0x01u;
+
+inline std::unordered_map<unsigned int, CObjBase*> & StubObjectRegistry()
+{
+        static std::unordered_map<unsigned int, CObjBase*> s_Registry;
+        return s_Registry;
+}
+
+inline CObjBase * StubFindObject( unsigned int uid )
+{
+        auto & registry = StubObjectRegistry();
+        auto it = registry.find( uid );
+        if ( it == registry.end())
+        {
+                return nullptr;
+        }
+        return it->second;
+}
+
+inline unsigned int StubParseUnsigned( const char * text )
+{
+        if ( text == nullptr )
+        {
+                return 0;
+        }
+        return static_cast<unsigned int>( std::strtoul( text, nullptr, 0 ));
+}
+
+void StubAttachObjectToContainer( CObjBase & object, unsigned int containerUid );
+
+inline CGString GetMergedFileName( const CGString & base, const char * name )
+{
+        std::string result;
+        if ( !base.IsEmpty())
+        {
+                result = (const char *) base;
+                if ( !result.empty() && result.back() != '/' )
+                {
+                        result.push_back( '/' );
+                }
+        }
+        if ( name != nullptr )
+        {
+                result += name;
+        }
+
+        CGString merged;
+        merged = result.c_str();
+        return merged;
+}
+
+struct StubWorld
+{
+        bool m_fSaveParity;
+
+        StubWorld() : m_fSaveParity( false ) {}
+};
+
+extern StubWorld g_World;
 
 constexpr WORD LOGM_INIT = 0x0100;
 constexpr WORD LOGM_SAVE = 0x0200;
@@ -95,7 +165,7 @@ struct CRealTime
 class CServer
 {
 public:
-        CServer() : m_loading( false ) {}
+        CServer() : m_iSavePeriod( 0 ), m_sWorldBaseDir(), m_loading( false ) {}
 
         bool IsLoading() const
         {
@@ -106,6 +176,9 @@ public:
         {
                 m_loading = loading;
         }
+
+        int m_iSavePeriod;
+        CGString m_sWorldBaseDir;
 
 private:
         bool m_loading;
@@ -189,12 +262,28 @@ private:
 class CScript
 {
 public:
-        CScript() : m_Open( false ) {}
+        CScript() :
+                m_Path(),
+                m_Open( false ),
+                m_Sections(),
+                m_CurrentSectionIndex( static_cast<size_t>( -1 )),
+                m_CurrentKeyIndex( 0 ),
+                m_CurrentKey(),
+                m_CurrentArg(),
+                m_Mode( Mode::None )
+        {
+        }
 
         bool Open( const char * path, unsigned int flags = 0 )
         {
                 m_Path = ( path != nullptr ) ? path : "";
                 m_Open = true;
+                m_Sections.clear();
+                m_CurrentSectionIndex = static_cast<size_t>( -1 );
+                m_CurrentKeyIndex = 0;
+                m_CurrentKey.clear();
+                m_CurrentArg.clear();
+                m_Mode = Mode::None;
 
                 if (( flags & OF_WRITE ) != 0 )
                 {
@@ -205,7 +294,7 @@ public:
                         }
 
                         std::ofstream output( m_Path.c_str(), mode );
-                        if ( !output.is_open())
+                        if ( ! output.is_open())
                         {
                                 m_Open = false;
                                 m_Path.clear();
@@ -213,7 +302,87 @@ public:
                         }
                 }
 
-                return true;
+                if (( flags & OF_READ ) != 0 )
+                {
+                        std::ifstream input( m_Path.c_str(), std::ios::in | std::ios::binary );
+                        if ( ! input.is_open())
+                        {
+                                m_Open = false;
+                                m_Path.clear();
+                                return false;
+                        }
+
+                        Section current;
+                        std::string line;
+                        while ( std::getline( input, line ))
+                        {
+                                if ( ! line.empty() && line.back() == '\r' )
+                                {
+                                        line.pop_back();
+                                }
+
+                                std::string trimmed = Trim( line );
+                                if ( trimmed.empty())
+                                {
+                                        continue;
+                                }
+                                if (( trimmed.size() >= 2 && trimmed.front() == '[' && trimmed.back() == ']' ))
+                                {
+                                        if ( ! current.m_Name.empty())
+                                        {
+                                                m_Sections.push_back( current );
+                                        }
+
+                                        current = Section();
+                                        std::string inside = Trim( trimmed.substr( 1, trimmed.size() - 2 ));
+                                        size_t spacePos = inside.find_first_of( " \t" );
+                                        if ( spacePos == std::string::npos )
+                                        {
+                                                current.m_Name = ToUpper( inside );
+                                                current.m_HeaderArg.clear();
+                                        }
+                                        else
+                                        {
+                                                current.m_Name = ToUpper( inside.substr( 0, spacePos ));
+                                                current.m_HeaderArg = Trim( inside.substr( spacePos + 1 ));
+                                        }
+                                        continue;
+                                }
+
+                                if ( trimmed[0] == ';' || ( trimmed.size() >= 2 && trimmed[0] == '/' && trimmed[1] == '/' ))
+                                {
+                                        continue;
+                                }
+
+                                if ( current.m_Name.empty())
+                                {
+                                        continue;
+                                }
+
+                                size_t equalsPos = trimmed.find( '=' );
+                                std::string key;
+                                std::string value;
+                                if ( equalsPos == std::string::npos )
+                                {
+                                        key = Trim( trimmed );
+                                        value.clear();
+                                }
+                                else
+                                {
+                                        key = Trim( trimmed.substr( 0, equalsPos ));
+                                        value = Trim( trimmed.substr( equalsPos + 1 ));
+                                }
+
+                                current.m_Entries.emplace_back( ToUpper( key ), value );
+                        }
+
+                        if ( ! current.m_Name.empty())
+                        {
+                                m_Sections.push_back( current );
+                        }
+                }
+
+                return m_Open;
         }
 
         bool Open( const char * path, int flags )
@@ -224,21 +393,117 @@ public:
         void Close()
         {
                 m_Open = false;
+                m_Sections.clear();
+                m_CurrentSectionIndex = static_cast<size_t>( -1 );
+                m_CurrentKeyIndex = 0;
+                m_CurrentKey.clear();
+                m_CurrentArg.clear();
+                m_Mode = Mode::None;
         }
 
         bool FindNextSection()
         {
-                return false;
+                if ( m_Sections.empty())
+                {
+                                m_Mode = Mode::None;
+                                return false;
+                }
+
+                if ( m_CurrentSectionIndex == static_cast<size_t>( -1 ))
+                {
+                        m_CurrentSectionIndex = 0;
+                }
+                else
+                {
+                        if ( m_CurrentSectionIndex + 1 >= m_Sections.size())
+                        {
+                                m_Mode = Mode::None;
+                                return false;
+                        }
+                        ++m_CurrentSectionIndex;
+                }
+
+                ResetIteration();
+                return true;
+        }
+
+        bool IsSectionType( const char * name ) const
+        {
+                if ( name == nullptr || m_CurrentSectionIndex >= m_Sections.size())
+                {
+                        return false;
+                }
+
+                return m_Sections[m_CurrentSectionIndex].m_Name == ToUpper( std::string( name ));
+        }
+
+        const char * GetSection() const
+        {
+                if ( m_CurrentSectionIndex >= m_Sections.size())
+                {
+                        return "";
+                }
+                return m_Sections[m_CurrentSectionIndex].m_Name.c_str();
         }
 
         const char * GetKey() const
         {
-                return "";
+                return m_CurrentKey.c_str();
         }
 
         const char * GetFilePath() const
         {
                 return m_Path.c_str();
+        }
+
+        const char * GetArgStr() const
+        {
+                if ( m_Mode == Mode::Key )
+                {
+                        return m_CurrentArg.c_str();
+                }
+                if ( m_CurrentSectionIndex >= m_Sections.size())
+                {
+                        return "";
+                }
+                return m_Sections[m_CurrentSectionIndex].m_HeaderArg.c_str();
+        }
+
+        long GetArgHex() const
+        {
+                return static_cast<long>( std::strtoul( GetArgStr(), nullptr, 0 ));
+        }
+
+        long GetArgVal() const
+        {
+                return static_cast<long>( std::strtol( GetArgStr(), nullptr, 0 ));
+        }
+
+        bool ReadKey()
+        {
+                if ( m_CurrentSectionIndex >= m_Sections.size())
+                {
+                        m_Mode = Mode::Section;
+                        return false;
+                }
+
+                Section & section = m_Sections[m_CurrentSectionIndex];
+                if ( m_CurrentKeyIndex >= section.m_Entries.size())
+                {
+                        m_Mode = Mode::Section;
+                        return false;
+                }
+
+                m_CurrentKey = section.m_Entries[m_CurrentKeyIndex].first;
+                m_CurrentArg = section.m_Entries[m_CurrentKeyIndex].second;
+                ++m_CurrentKeyIndex;
+                m_Mode = Mode::Key;
+                return true;
+        }
+
+        bool ReadKeyParse()
+        {
+                return ReadKey();
         }
 
         void WriteStr( const char *, ... )
@@ -251,8 +516,57 @@ public:
         }
 
 private:
+        enum class Mode
+        {
+                None,
+                Section,
+                Key
+        };
+
+        struct Section
+        {
+                std::string m_Name;
+                std::string m_HeaderArg;
+                std::vector<std::pair<std::string,std::string>> m_Entries;
+        };
+
+        static std::string Trim( const std::string & value )
+        {
+                size_t start = value.find_first_not_of( " \t\r\n" );
+                if ( start == std::string::npos )
+                {
+                        return std::string();
+                }
+                size_t end = value.find_last_not_of( " \t\r\n" );
+                return value.substr( start, end - start + 1 );
+        }
+
+        static std::string ToUpper( const std::string & value )
+        {
+                std::string result = value;
+                std::transform( result.begin(), result.end(), result.begin(), []( unsigned char ch )
+                {
+                        return static_cast<char>( std::toupper( ch ));
+                });
+                return result;
+        }
+
+        void ResetIteration()
+        {
+                m_CurrentKeyIndex = 0;
+                m_CurrentKey.clear();
+                m_CurrentArg.clear();
+                m_Mode = Mode::Section;
+        }
+
         std::string m_Path;
         bool m_Open;
+        std::vector<Section> m_Sections;
+        size_t m_CurrentSectionIndex;
+        size_t m_CurrentKeyIndex;
+        std::string m_CurrentKey;
+        std::string m_CurrentArg;
+        Mode m_Mode;
 };
 
 class CVarDefCont
@@ -331,8 +645,14 @@ public:
                 m_TopPoint(),
                 m_ContainedPoint(),
                 m_IsTopLevel( false ),
-                m_IsInContainer( false )
+                m_IsInContainer( false ),
+                m_Deleted( false )
         {
+        }
+
+        virtual ~CObjBase()
+        {
+                StubObjectRegistry().erase( m_UID );
         }
 
         virtual bool IsChar() const
@@ -347,7 +667,13 @@ public:
 
         void SetUID( unsigned int uid )
         {
+                auto & registry = StubObjectRegistry();
+                registry.erase( m_UID );
                 m_UID = uid;
+                if ( uid != 0 )
+                {
+                        registry[m_UID] = this;
+                }
         }
 
         unsigned int GetUID() const
@@ -466,9 +792,64 @@ public:
                 output << "UID=" << m_UID << '\n';
         }
 
-        virtual bool r_Load( CScript & )
+        virtual bool r_Load( CScript & script )
         {
+                bool fHasContainer = false;
+                while ( script.ReadKey())
+                {
+                        const char * pszKey = script.GetKey();
+                        const char * pszArg = script.GetArgStr();
+                        if ( pszKey == nullptr )
+                        {
+                                continue;
+                        }
+
+                        if ( !strcasecmp( pszKey, "UID" ))
+                        {
+                                SetUID( StubParseUnsigned( pszArg ));
+                        }
+                        else if ( !strcasecmp( pszKey, "NAME" ))
+                        {
+                                SetName( pszArg );
+                        }
+                        else if ( !strcasecmp( pszKey, "CONT" ))
+                        {
+                                StubAttachObjectToContainer( *this, StubParseUnsigned( pszArg ));
+                                fHasContainer = true;
+                        }
+                        else if ( !strcasecmp( pszKey, "P" ))
+                        {
+                                int x = 0;
+                                int y = 0;
+                                int z = 0;
+                                if ( pszArg != nullptr )
+                                {
+                                        std::sscanf( pszArg, "%d,%d,%d", &x, &y, &z );
+                                        SetTopPoint( CPointMap( x, y, z ));
+                                }
+                        }
+                }
+
+                if ( ! fHasContainer )
+                {
+                        SetInContainer( false );
+                        SetContainer( nullptr );
+                        SetTopLevel( true );
+                        SetTopLevelObj( this );
+                }
+
                 return true;
+        }
+
+        virtual void Delete()
+        {
+                m_Deleted = true;
+                StubObjectRegistry().erase( m_UID );
+        }
+
+        bool IsDeleted() const
+        {
+                return m_Deleted;
         }
 
 private:
@@ -483,6 +864,7 @@ private:
         CPointMap m_ContainedPoint;
         bool m_IsTopLevel;
         bool m_IsInContainer;
+        bool m_Deleted;
 };
 
 class CAccount
@@ -597,14 +979,47 @@ private:
         CAccount * m_pAccount;
 };
 
-class CChar : public CObjBase
+class CContainer
 {
 public:
-        CChar() : m_pPlayer( nullptr ) {}
+        CContainer();
+
+        CItem * GetContentHead() const
+        {
+                return m_ContentHead;
+        }
+
+        const std::vector<CItem*> & GetContents() const
+        {
+                return m_Contents;
+        }
+
+protected:
+        void AppendContent( CItem * item );
+
+private:
+        CItem * m_ContentHead;
+        std::vector<CItem*> m_Contents;
+};
+
+class CChar : public CObjBase, public CContainer
+{
+public:
+        CChar() : CContainer(), m_pPlayer( nullptr ) {}
 
         bool IsChar() const override
         {
                 return true;
+        }
+
+        static CChar * CreateBasic( CREID_TYPE )
+        {
+                return new CChar();
+        }
+
+        bool IsStat( unsigned int ) const
+        {
+                return false;
         }
 
         void SetPlayer( CPlayer * player )
@@ -615,14 +1030,19 @@ public:
         CPlayer * m_pPlayer;
 };
 
-class CItem : public CObjBase
+class CItem : public CObjBase, public CContainer
 {
 public:
-        CItem() : m_Equipped( false ) {}
+        CItem() : CContainer(), m_Equipped( false ), m_Next( nullptr ) {}
 
         bool IsItem() const override
         {
                 return true;
+        }
+
+        static CItem * CreateScript( ITEMID_TYPE )
+        {
+                return new CItem();
         }
 
         bool IsEquipped() const
@@ -635,9 +1055,71 @@ public:
                 m_Equipped = equipped;
         }
 
+        CItem * GetNext() const
+        {
+                return m_Next;
+        }
+
+        void SetNext( CItem * next )
+        {
+                m_Next = next;
+        }
+
+        void AddContainedItem( CItem * item )
+        {
+                AppendContent( item );
+        }
+
 private:
         bool m_Equipped;
+        CItem * m_Next;
 };
+
+inline CContainer::CContainer() : m_ContentHead( nullptr ), m_Contents()
+{
+}
+
+inline void CContainer::AppendContent( CItem * item )
+{
+        if ( item == nullptr )
+        {
+                return;
+        }
+
+        item->SetNext( m_ContentHead );
+        m_ContentHead = item;
+        m_Contents.push_back( item );
+}
+
+inline void StubAttachObjectToContainer( CObjBase & object, unsigned int containerUid )
+{
+        CObjBase * pContainer = StubFindObject( containerUid );
+        if ( pContainer == nullptr )
+        {
+                object.SetContainer( nullptr );
+                object.SetInContainer( false );
+                return;
+        }
+
+        object.SetContainer( pContainer );
+        object.SetInContainer( true );
+        object.SetTopLevel( false );
+
+        CObjBaseTemplate * pTop = pContainer->GetTopLevelObj();
+        if ( pTop == nullptr )
+        {
+                pTop = pContainer;
+        }
+        object.SetTopLevelObj( pTop );
+
+        if ( CItem * pContainerItem = dynamic_cast<CItem*>( pContainer ))
+        {
+                if ( CItem * pItem = dynamic_cast<CItem*>( &object ))
+                {
+                        pContainerItem->AddContainedItem( pItem );
+                }
+        }
+}
 
 class CSector {};
 class CGMPage {};

--- a/tests/stubs/mysql_stubs.cpp
+++ b/tests/stubs/mysql_stubs.cpp
@@ -13,6 +13,7 @@
 
 CLog g_Log;
 CServer g_Serv;
+StubWorld g_World;
 
 namespace
 {


### PR DESCRIPTION
## Summary
- restore `PersistWorldObject` to take an explicit `includeContents` flag and plumb the value from `SaveWorldObjectInternal`
- recurse through container children when requested and log unexpected sections via `script.GetKey()` during deserialization
- extend the unit test stubs with a lightweight `CContainer` implementation so container iteration works under unit tests

## Testing
- make -C tests
- ./tests/storage_tests

------
https://chatgpt.com/codex/tasks/task_e_68dff4c39b4483279589aeb7922d3a8c