### PR TITLE
Add MariaDB timer persistence and schema v5 migration

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -189,6 +189,38 @@ public:
                 int m_iAgeHours;
         };
 
+        struct TimerRecord
+        {
+                enum class Type : unsigned int
+                {
+                        Unknown = 0,
+                        Character = 1,
+                        Item = 2,
+                        Script = 3
+                };
+
+                unsigned long long m_id;
+                bool m_fHasCharacter;
+                unsigned long long m_uCharacterUid;
+                bool m_fHasItem;
+                unsigned long long m_uItemUid;
+                long long m_iExpiresAt;
+                Type m_eType;
+                CGString m_sData;
+
+                TimerRecord() :
+                        m_id( 0 ),
+                        m_fHasCharacter( false ),
+                        m_uCharacterUid( 0 ),
+                        m_fHasItem( false ),
+                        m_uItemUid( 0 ),
+                        m_iExpiresAt( 0 ),
+                        m_eType( Type::Unknown ),
+                        m_sData()
+                {
+                }
+        };
+
         bool Start( const CServerMySQLConfig & config );
         bool Connect( const CServerMySQLConfig & config )
         {
@@ -256,6 +288,12 @@ public:
         bool ApplyWorldObjectData( CObjBase & object, const CGString & serialized ) const;
         bool LoadGMPages( std::vector<GMPageRecord> & pages );
         bool LoadServers( std::vector<ServerRecord> & servers );
+        bool LoadTimers( std::vector<TimerRecord> & timers );
+
+        bool SaveTimers( const std::vector<TimerRecord> & timers );
+        bool UpsertTimerForObject( const CObjBase & object, long long expiresInTicks );
+        bool DeleteTimersForObject( const CObjBase & object );
+        bool ClearTimers();
 
         CGString GetAccountNameById( unsigned int accountId );
 

--- a/GraySvr/Storage/Schema/SchemaManager.h
+++ b/GraySvr/Storage/Schema/SchemaManager.h
@@ -38,6 +38,7 @@ namespace Schema
                 bool ApplyMigration_1_2( MySqlStorageService & storage );
                 bool ApplyMigration_2_3( MySqlStorageService & storage );
                 bool ApplyMigration_3_4( MySqlStorageService & storage );
+                bool ApplyMigration_4_5( MySqlStorageService & storage );
                 bool EnsureColumnExists( MySqlStorageService & storage, const CGString & table, const char * column, const char * definition );
                 bool ColumnExists( MySqlStorageService & storage, const CGString & table, const char * column ) const;
                 bool InsertOrUpdateSchemaValue( MySqlStorageService & storage, int id, int value );

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -4947,6 +4947,8 @@ public:
         size_t  m_uStorageLoadGMPageIndex;
         std::vector<MySqlStorageService::ServerRecord> m_StorageLoadServers;
         size_t  m_uStorageLoadServerIndex;
+        std::vector<MySqlStorageService::TimerRecord> m_StorageLoadTimers;
+        size_t  m_uStorageLoadTimerIndex;
 
         // World data.
 	CSector m_Sectors[ SECTOR_QTY ];
@@ -4983,6 +4985,7 @@ private:
         bool SaveStorageSector( CSector & sector );
         bool SaveStorageGMPages();
         bool SaveStorageServers();
+        bool SaveStorageTimers();
         bool SaveObjectToStorage( CObjBase * pObj );
         bool BeginStorageSave();
         void AbortStorageSave();

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -95,7 +95,7 @@ managed by the connection manager, so they can freely execute DDL and DML using
 
 ## Schema reference
 
-The current schema version is **4**. Table names below omit the optional prefix
+The current schema version is **5**. Table names below omit the optional prefix
 configured through `MYSQLPREFIX`.
 
 ### `schema_version`
@@ -104,7 +104,7 @@ Tracks migration and operational metadata. Seeded by the schema manager.
 
 | `id` | Purpose | Typical values |
 | ---- | ------- | -------------- |
-| 1 | Schema revision (`CURRENT_SCHEMA_VERSION`). | `4` |
+| 1 | Schema revision (`CURRENT_SCHEMA_VERSION`). | `5` |
 | 2 | Legacy account import flag (`0` pending, `1` complete). | `0` or `1` |
 | 3 | World save counter (incremented for every completed save). | `0+` |
 | 4 | World save completion flag (`0` = interrupted, `1` = success). | `0` or `1` |
@@ -152,9 +152,14 @@ Tracks migration and operational metadata. Seeded by the schema manager.
   metadata, contact details, localisation information and ageing statistics.
 
 `timers`
-: Auxiliary timers that back scheduled operations from the classic scripts.
+: Auxiliary timers that back scheduled operations from the classic scripts. Each
+  row references a persisted world object via `character_uid` or `item_uid`,
+  both of which point to `<prefix>world_objects`.`uid`. The `expires_at` column
+  stores the remaining world ticks (1 tick = 100 ms) until the timer fires and
+  `type` distinguishes character (`1`) from item (`2`) timers. Script engines
+  may persist additional payloads in `data` for future extensions.
 
-### World persistence (`schema` version ≥ 3, current version 4)
+### World persistence (`schema` version ≥ 3, current version 5)
 
 `world_objects`
 : Metadata for every persisted object (characters and items). Stores the base

--- a/docs/mysql-schema.sql
+++ b/docs/mysql-schema.sql
@@ -179,11 +179,11 @@ CREATE TABLE IF NOT EXISTS `sphere_timers` (
   PRIMARY KEY (`id`),
   KEY `ix_timers_character` (`character_uid`),
   KEY `ix_timers_item` (`item_uid`),
-  CONSTRAINT `fk_timers_character`
-    FOREIGN KEY (`character_uid`) REFERENCES `sphere_characters`(`uid`)
+  CONSTRAINT `fk_timers_character_world`
+    FOREIGN KEY (`character_uid`) REFERENCES `sphere_world_objects`(`uid`)
     ON DELETE CASCADE,
-  CONSTRAINT `fk_timers_item`
-    FOREIGN KEY (`item_uid`) REFERENCES `sphere_items`(`uid`)
+  CONSTRAINT `fk_timers_item_world`
+    FOREIGN KEY (`item_uid`) REFERENCES `sphere_world_objects`(`uid`)
     ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/docs/storage-migration.md
+++ b/docs/storage-migration.md
@@ -16,7 +16,7 @@ schema manager that centralises migrations.
 - **Repository layer** – consolidates SQL used for accounts, world objects,
   timers and GM pages. Each repository owns its prepared statements, reducing
   duplication and improving error reporting.
-- **Schema manager** – applies migrations up to schema version **4**, extends
+- **Schema manager** – applies migrations up to schema version **5**, extends
   legacy tables when new columns are required and records world-save status in
   dedicated rows of `<prefix>schema_version`.
 


### PR DESCRIPTION
## Summary
- persist world, character, and item timers through MySqlStorageService, including runtime upserts and world save/load integration
- add schema v5 migration to retarget timer foreign keys to world_objects and document the new schema
- extend world save bookkeeping to handle timer stages and prevent duplicate object instantiation during MySQL loads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01808316c83278070c158c97d1bcb