### PR TITLE
Delay timer persistence until objects exist in storage

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -338,6 +338,7 @@ private:
         CGString EscapeString( const TCHAR * pszInput ) const;
         CGString FormatStringValue( const CGString & value ) const;
         CGString FormatOptionalStringValue( const CGString & value ) const;
+        bool SyncObjectTimer( const CObjBase & object );
         CGString FormatDateTimeValue( const CGString & value ) const;
         CGString FormatDateTimeValue( const CRealTime & value ) const;
         CGString FormatIPAddressValue( const CGString & value ) const;

--- a/tests/stubs/graysvr.h
+++ b/tests/stubs/graysvr.h
@@ -99,8 +99,19 @@ inline CGString GetMergedFileName( const CGString & base, const char * name )
 struct StubWorld
 {
         bool m_fSaveParity;
+        int m_Time;
 
-        StubWorld() : m_fSaveParity( false ) {}
+        StubWorld() : m_fSaveParity( false ), m_Time( 0 ) {}
+
+        int GetTime() const
+        {
+                return m_Time;
+        }
+
+        void SetTime( int time )
+        {
+                m_Time = time;
+        }
 };
 
 extern StubWorld g_World;
@@ -646,13 +657,35 @@ public:
                 m_ContainedPoint(),
                 m_IsTopLevel( false ),
                 m_IsInContainer( false ),
-                m_Deleted( false )
+                m_Deleted( false ),
+                m_TimeoutAt( 0 )
         {
         }
 
         virtual ~CObjBase()
         {
                 StubObjectRegistry().erase( m_UID );
+        }
+
+        virtual void SetTimeout( int iDelayInTicks )
+        {
+                if ( iDelayInTicks < 0 )
+                {
+                        m_TimeoutAt = 0;
+                        return;
+                }
+
+                m_TimeoutAt = g_World.GetTime() + iDelayInTicks;
+        }
+
+        bool IsTimerSet() const
+        {
+                return m_TimeoutAt != 0;
+        }
+
+        int GetTimerDiff() const
+        {
+                return m_TimeoutAt - g_World.GetTime();
         }
 
         virtual bool IsChar() const
@@ -865,6 +898,7 @@ private:
         bool m_IsTopLevel;
         bool m_IsInContainer;
         bool m_Deleted;
+        int m_TimeoutAt;
 };
 
 class CAccount


### PR DESCRIPTION
## Summary
- skip timer delete/upsert work during `CObjBase::SetTimeout` for freshly created or deleted objects while still queuing the save
- add `MySqlStorageService::SyncObjectTimer` and invoke it after successful world object saves to delete or upsert timers based on the object timeout
- expand the unit test stubs and add coverage to confirm saving a new character with a timeout creates the timer without foreign key errors

## Testing
- make -C tests
- ./tests/storage_tests

------
https://chatgpt.com/codex/tasks/task_e_68e0342a598c83279113863bb5a7cae6