### PR TITLE
Add automatic MySQL reconnection handling

### DIFF
--- a/GraySvr/MySqlStorageService.h
+++ b/GraySvr/MySqlStorageService.h
@@ -319,6 +319,8 @@ private:
 
         bool Query( const CGString & query, std::unique_ptr<Storage::IDatabaseResult> * pResult = NULL );
         bool ExecuteQuery( const CGString & query );
+        bool TryReconnect();
+        bool ShouldAttemptReconnect( unsigned int errorCode ) const;
         bool EnsureSchemaVersionTable();
         bool SetSchemaVersion( int version );
         bool ApplyMigration( int fromVersion );

--- a/GraySvr/Storage/MySql/ConnectionManager.h
+++ b/GraySvr/Storage/MySql/ConnectionManager.h
@@ -26,6 +26,7 @@ namespace MySql
                 ~ConnectionManager();
 
                 bool Connect( const CServerMySQLConfig & config, ConnectionDetails & outDetails );
+                bool Reconnect( ConnectionDetails & outDetails );
                 void Disconnect();
 
                 bool IsConnected() const;


### PR DESCRIPTION
## Summary
- attempt to reconnect and retry failed MySQL operations when connection-related errors are detected
- refresh cached charset/collation data after reconnecting to keep service state consistent
- expose a ConnectionManager::Reconnect helper so the storage service can rebuild the connection pool on demand

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e03ceab6cc8327adb99d7f17357d4a