### PR TITLE
Add IScriptTextStream abstraction to CScript

### DIFF
--- a/Common/cfile.h
+++ b/Common/cfile.h
@@ -21,6 +21,15 @@
 #define OF_TEXT				0x2000
 #define OF_BINARY			0x8000
 
+class IScriptTextStream
+{
+public:
+	virtual ~IScriptTextStream() {}
+	virtual TCHAR * ReadLine( TCHAR FAR * pBuffer, size_t sizemax ) = 0;
+	virtual bool Write( const void FAR * pData, size_t iLen ) = 0;
+	virtual bool Seek( long offset = 0, int origin = SEEK_SET ) = 0;
+};
+
 class CGFile	// try to be compatible with MFC CFile class.
 {
 private:


### PR DESCRIPTION
## Summary
- add an IScriptTextStream interface that abstracts the text stream operations used by scripts
- extend CScript with a file-backed stream adapter, stream-aware constructors, and helper wrappers
- refactor CScript open/read/write routines to call the injected stream implementation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0daf1b3e88327afa544a64fa60c52