### PR TITLE
Refine console banner and progress animation

### DIFF
--- a/GraySvr/CServer.cpp
+++ b/GraySvr/CServer.cpp
@@ -2938,23 +2938,40 @@ void CServer::PrintStr( const TCHAR * pStr ) const
 
 int CServer::PrintPercent( long iCount, long iTotal )
 {
-	static int prev = 100;
-	// These vals can get very large. so use MulDiv to prevent overflow. (not IMULDIV)
-	DEBUG_CHECK( iCount >= 0 );
-	DEBUG_CHECK( iTotal >= 0 );
-	if ( iTotal <= 0 )
-		return( 100 );
-    int iPercent = MulDiv( iCount, 100, iTotal );
-	if (prev == iPercent)//avoid updating if the value is the same as before, updating it too much will slow down console output and also the loading
-	{
-		return iPercent;
-	}
-	prev = iPercent;
-	CGString sProgress;
-	int len = sProgress.Format( "%d%%  ", iPercent );
-	PrintStr( sProgress );
-	while ( len-- ) PrintStr( "\x08" );
-	return( iPercent );
+        static int prevPercent = 100;
+        static size_t frameIndex = 0;
+        // These vals can get very large. so use MulDiv to prevent overflow. (not IMULDIV)
+        DEBUG_CHECK( iCount >= 0 );
+        DEBUG_CHECK( iTotal >= 0 );
+        if ( iTotal <= 0 )
+                return( 100 );
+        int iPercent = MulDiv( iCount, 100, iTotal );
+        if ( prevPercent == iPercent )     // avoid excessive redraws if the value is unchanged
+        {
+                return iPercent;
+        }
+        prevPercent = iPercent;
+        static const char * const kClockFrames[] =
+        {
+                "[o^]",
+                "[o>]",
+                "[ov]",
+                "[o<]",
+        };
+        const char * frame = kClockFrames[frameIndex];
+        frameIndex = (frameIndex + 1) % COUNTOF(kClockFrames);
+        CGString sProgress;
+        int len = sProgress.Format( "%s  ", frame );
+        PrintStr( sProgress );
+        while ( len-- )
+        {
+                PrintStr( "\x08" );
+        }
+        if ( iPercent >= 100 )
+        {
+                frameIndex = 0;
+        }
+        return( iPercent );
 }
 
 const COreDef * CServer::GetOreColor( COLOR_TYPE color ) const

--- a/GraySvr/graysvr.cpp
+++ b/GraySvr/graysvr.cpp
@@ -78,6 +78,8 @@
 
 #include "graysvr.h"	// predef header.
 #include <cstring>
+#include <cstdio>
+#include <string>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -591,11 +593,53 @@ namespace
         constexpr WORD kNoConsoleColor = 0;
 }
 
-void SetConsoleColor(WORD)
+void SetConsoleColor(WORD color)
 {
-        // Colorized console output is a Windows-specific feature.  On
-        // POSIX terminals we simply skip the attribute change and leave
-        // the text in the default color.
+        const bool intensity = ((color & FOREGROUND_INTENSITY) != 0);
+        const bool red = ((color & FOREGROUND_RED) != 0);
+        const bool green = ((color & FOREGROUND_GREEN) != 0);
+        const bool blue = ((color & FOREGROUND_BLUE) != 0);
+
+        if ( !red && !green && !blue )
+        {
+                fputs("\033[0m", stdout);
+                return;
+        }
+
+        int ansiCode = 37;    // default to white
+
+        if ( red && green && blue )
+        {
+                ansiCode = intensity ? 97 : 37;
+        }
+        else if ( red && green )
+        {
+                ansiCode = intensity ? 93 : 33;
+        }
+        else if ( red && blue )
+        {
+                ansiCode = intensity ? 95 : 35;
+        }
+        else if ( green && blue )
+        {
+                ansiCode = intensity ? 96 : 36;
+        }
+        else if ( red )
+        {
+                ansiCode = intensity ? 91 : 31;
+        }
+        else if ( green )
+        {
+                ansiCode = intensity ? 92 : 32;
+        }
+        else if ( blue )
+        {
+                ansiCode = intensity ? 94 : 34;
+        }
+
+        char sequence[16];
+        snprintf( sequence, sizeof( sequence ), "\033[%dm", ansiCode );
+        fputs( sequence, stdout );
 }
 
 #ifndef FOREGROUND_RED
@@ -611,6 +655,117 @@ void SetConsoleColor(WORD)
 #define FOREGROUND_INTENSITY     kNoConsoleColor
 #endif
 #endif
+
+namespace
+{
+        constexpr size_t kBannerInnerWidth = 70;
+        constexpr size_t kBannerContentWidth = kBannerInnerWidth - 2;
+        constexpr size_t kLabelWidth = 10;
+
+        std::string FormatBannerLine(std::string text)
+        {
+                if (text.size() > kBannerContentWidth)
+                {
+                        text.resize(kBannerContentWidth);
+                }
+
+                if (text.size() < kBannerContentWidth)
+                {
+                        text.append(kBannerContentWidth - text.size(), ' ');
+                }
+
+                return std::string("| ") + text + " |";
+        }
+
+        std::string FormatCenteredLine(std::string text)
+        {
+                if (text.size() > kBannerContentWidth)
+                {
+                        text.resize(kBannerContentWidth);
+                }
+
+                const size_t totalPadding = kBannerContentWidth - text.size();
+                const size_t leftPadding = totalPadding / 2;
+                const size_t rightPadding = totalPadding - leftPadding;
+
+                return std::string("| ")
+                        + std::string(leftPadding, ' ')
+                        + text
+                        + std::string(rightPadding, ' ')
+                        + " |";
+        }
+
+        std::string FormatDetailLine(std::string label, std::string value)
+        {
+                if (label.size() > kLabelWidth)
+                {
+                        label.resize(kLabelWidth);
+                }
+                else
+                {
+                        label.append(kLabelWidth - label.size(), ' ');
+                }
+
+                std::string content = label + " | " + value;
+                if (content.size() > kBannerContentWidth)
+                {
+                        content.resize(kBannerContentWidth);
+                }
+
+                return FormatBannerLine(content);
+        }
+
+        std::string FormatEmptyLine()
+        {
+                return std::string("| ") + std::string(kBannerContentWidth, ' ') + " |";
+        }
+
+        void PrintStartupBanner()
+        {
+                const std::string top = "+" + std::string(kBannerInnerWidth, '=') + "+";
+                const std::string section = "+" + std::string(kBannerInnerWidth, '-') + "+";
+                const std::string bottom = "+" + std::string(kBannerInnerWidth, '=') + "+";
+
+                std::string description(g_szServerDescription);
+                std::string productLine = description;
+                std::string authorLine;
+
+                const std::string byToken = " by ";
+                const size_t tokenPos = description.find(byToken);
+                if (tokenPos != std::string::npos)
+                {
+                        productLine = description.substr(0, tokenPos);
+                        authorLine = description.substr(tokenPos + byToken.size());
+                }
+
+                const std::string buildInfo = std::string(__DATE__) + " " + __TIME__;
+                const std::string docsInfo = "docs/README.md";
+                const std::string sourceInfo = "github.com/keni2006/Sphere-51x";
+                const std::string consoleInfo = "'?': help  |  'S': status  |  'X': shutdown";
+
+                const std::string emptyLine = FormatEmptyLine();
+                const std::string headerLine = FormatCenteredLine(productLine);
+                const std::string authorDisplay = authorLine.empty() ? emptyLine : FormatCenteredLine(authorLine);
+                const std::string buildLine = FormatDetailLine("Build", buildInfo);
+                const std::string docsLine = FormatDetailLine("Docs", docsInfo);
+                const std::string sourceLine = FormatDetailLine("Source", sourceInfo);
+                const std::string consoleLine = FormatDetailLine("Console", consoleInfo);
+
+                g_Log.Event( LOGM_INIT | LOGM_STYLE_NOCATEGORY,
+                        "\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+                        top.c_str(),
+                        emptyLine.c_str(),
+                        headerLine.c_str(),
+                        authorDisplay.c_str(),
+                        emptyLine.c_str(),
+                        section.c_str(),
+                        buildLine.c_str(),
+                        docsLine.c_str(),
+                        sourceLine.c_str(),
+                        consoleLine.c_str(),
+                        bottom.c_str());
+        }
+}
 
 int CLog::EventStr(WORD wMask, const TCHAR* pszMsg)
 {
@@ -649,83 +804,150 @@ int CLog::EventStr(WORD wMask, const TCHAR* pszMsg)
 		}
 
 		CGString sTime;
-		sTime.Format("%02d:%02d:", NewStamp.m_Hour, NewStamp.m_Min);
+		sTime.Format("[%02d:%02d]", NewStamp.m_Hour, NewStamp.m_Min);
 		m_Stamp = NewStamp;
 
-		const TCHAR* pszLabel = NULL;
+		const WORD kDefaultColor = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+		WORD labelColor = kDefaultColor;
+		const TCHAR * pszLabel = NULL;
 
-		switch (wMask & 0x07)
+		const WORD severity = ( wMask & 0x0f );
+
+		switch ( severity )
 		{
-		case LOGL_FATAL:   // fatal error!
-			pszLabel = "FATAL:";
-			SetConsoleColor(FOREGROUND_RED | FOREGROUND_INTENSITY); //red
+		case LOGL_FATAL:	// fatal error!
+			pszLabel = "[FATAL]";
+			labelColor = FOREGROUND_RED | FOREGROUND_INTENSITY;
 			break;
-		case LOGL_CRIT:    // critical.
-			pszLabel = "CRITICAL:";
-			SetConsoleColor(FOREGROUND_RED | FOREGROUND_INTENSITY); //red
+		case LOGL_CRIT:	// critical.
+			pszLabel = "[CRITICAL]";
+			labelColor = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 			break;
-		case LOGL_ERROR:   // non-fatal errors.
-			pszLabel = "ERROR:";
-			SetConsoleColor(FOREGROUND_RED); // 
+		case LOGL_ERROR:	// non-fatal errors.
+			pszLabel = "[ERROR]";
+			labelColor = FOREGROUND_RED | FOREGROUND_INTENSITY;
 			break;
 		case LOGL_WARN:
-			pszLabel = "WARNING:";
-			SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN); // yellow
+			pszLabel = "[WARN]";
+			labelColor = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+			break;
+		case LOGL_EVENT:
+			pszLabel = "[INFO]";
+			labelColor = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+			break;
+		case LOGL_TRACE:
+			pszLabel = "[TRACE]";
+			labelColor = FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 			break;
 		default:
-			SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);//white
-			
+			if (( wMask & LOGM_INIT ) == 0 )
+			{
+				pszLabel = "[INFO]";
+				labelColor = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+			}
 			break;
 		}
-	
 
-		//SHOULD BE REWRITTEN KINGA SLOWLY BUT WORK//
-		/////////////////////////////////////////////
-	
-	// Get the script context. (if there is one)
-	CGString sScriptContext;
-	if ( m_pScriptContext )
-	{
-		sScriptContext.Format( "(%s,%d)", m_pScriptContext->GetFileTitle(), m_pScriptContext->GetLineNumber());
-	}
+                const bool showCategories = ((wMask & LOGM_STYLE_NOCATEGORY) == 0);
+                const WORD categoryMask = wMask & ~LOGM_STYLE_NOCATEGORY;
 
-	// Print to screen.
-	if (!(wMask & LOGM_INIT) && !g_Serv.IsLoading())
-	{
-	//	SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE); // white for time
-		g_Serv.PrintStr(sTime);
-	}
-	if (pszLabel)
-	{
-		g_Serv.PrintStr(pszLabel);
-		SetConsoleColor(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE); // white after printing label
-	}
+                static const struct
+                {
+                        WORD mask;
+                        const char * name;
+                } kLogCategories[] =
+                {
+			{ LOGM_INIT, "INIT" },
+			{ LOGM_SAVE, "SAVE" },
+			{ LOGM_ACCOUNTS, "ACCT" },
+			{ LOGM_CLIENTS_LOG, "CLIENT" },
+			{ LOGM_GM_PAGE, "GM_PAGE" },
+			{ LOGM_PLAYER_SPEAK, "CHAT" },
+			{ LOGM_GM_CMDS, "GM_CMD" },
+			{ LOGM_CHEAT, "CHEAT" },
+			{ LOGM_KILLS, "KILL" },
+		};
 
-	if (!sScriptContext.IsEmpty())
-	{
-		g_Serv.PrintStr(sScriptContext);
-	}
-	size_t messageLength = strlen(pszMsg);
-	bool hasTrailingNewLine = (messageLength > 0) && (pszMsg[messageLength - 1] == '\n');
-	g_Serv.PrintStr(pszMsg);
-	if ( !hasTrailingNewLine )
-	{
-		g_Serv.PrintStr("\n");
-	}
+                std::string categoryBuffer[COUNTOF(kLogCategories)];
+                size_t categoryCount = 0;
+                for ( size_t i = 0; i < COUNTOF(kLogCategories); ++i )
+                {
+                        if (showCategories && ( categoryMask & kLogCategories[i].mask ) != 0 )
+                        {
+                                categoryBuffer[categoryCount++] = "[" + std::string( kLogCategories[i].name ) + "]";
+                        }
+                }
 
-	
-	// Print to log file.
-	WriteStr( sTime );
-	if ( pszLabel )	WriteStr( pszLabel );
-	if ( ! sScriptContext.IsEmpty())
-	{
-		WriteStr( sScriptContext );
-	}
-	WriteStr( pszMsg );
-	if ( !hasTrailingNewLine )
-	{
-		WriteStr("\n");
-	}
+		// Get the script context. (if there is one)
+		CGString sScriptContext;
+		if ( m_pScriptContext )
+		{
+			sScriptContext.Format( "(%s,%d)", m_pScriptContext->GetFileTitle(), m_pScriptContext->GetLineNumber());
+		}
+
+               if (!(wMask & LOGM_INIT) && !g_Serv.IsLoading())
+               {
+                       SetConsoleColor( FOREGROUND_GREEN | FOREGROUND_BLUE );
+                       g_Serv.PrintStr(sTime);
+                       g_Serv.PrintStr(" ");
+                       SetConsoleColor(kDefaultColor);
+               }
+
+		if (pszLabel)
+		{
+			SetConsoleColor(labelColor);
+			g_Serv.PrintStr(pszLabel);
+			SetConsoleColor(kDefaultColor);
+			g_Serv.PrintStr(" ");
+		}
+
+                for ( size_t i = 0; i < categoryCount; ++i )
+                {
+                        SetConsoleColor( FOREGROUND_GREEN | FOREGROUND_BLUE );
+                        g_Serv.PrintStr( categoryBuffer[i].c_str());
+                        SetConsoleColor( kDefaultColor );
+                        g_Serv.PrintStr( " " );
+		}
+
+		if (!sScriptContext.IsEmpty())
+		{
+			SetConsoleColor( FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
+			g_Serv.PrintStr(sScriptContext);
+			SetConsoleColor(kDefaultColor);
+			g_Serv.PrintStr(" ");
+		}
+		size_t messageLength = strlen(pszMsg);
+		bool hasTrailingNewLine = (messageLength > 0) && (pszMsg[messageLength - 1] == '\n');
+		g_Serv.PrintStr(pszMsg);
+		if ( !hasTrailingNewLine )
+		{
+			g_Serv.PrintStr("\n");
+		}
+		SetConsoleColor(kDefaultColor);
+
+		// Print to log file.
+		WriteStr( sTime );
+		WriteStr( " ");
+		if ( pszLabel )
+		{
+			WriteStr( pszLabel );
+			WriteStr( " ");
+		}
+                for ( size_t i = 0; i < categoryCount; ++i )
+                {
+                        WriteStr( categoryBuffer[i].c_str());
+                        WriteStr( " ");
+                }
+		if ( ! sScriptContext.IsEmpty())
+		{
+			WriteStr( sScriptContext );
+			WriteStr( " ");
+		}
+		WriteStr( pszMsg );
+		if ( !hasTrailingNewLine )
+		{
+			WriteStr("\n");
+		}
 
 	}
 	catch (...)
@@ -918,10 +1140,7 @@ int _cdecl main(int argc, char * argv[])
 	SetConsoleCtrlHandler( ConsoleHandlerRoutine, TRUE );
 #endif
 
-	g_Log.Event( LOGM_INIT, "\n%s\n"
-		"Compiled at " __DATE__ " (" __TIME__ ")\n"
-		"\n",
-		g_szServerDescription );
+        PrintStartupBanner();
 
 	if ( ! g_Serv.Load())
 	{
@@ -957,7 +1176,6 @@ int _cdecl main(int argc, char * argv[])
 	g_Log.Event( LOGM_INIT, _TEXT("Startup complete. items=%d, chars=%d\n"), g_Serv.StatGet(SERV_STAT_ITEMS), g_Serv.StatGet(SERV_STAT_CHARS));
 
 #ifdef _WIN32
-	g_Log.Event( LOGM_INIT, "Press '?' for console commands\n" );
 
 	if ( g_osInfo.dwPlatformId == VER_PLATFORM_WIN32_NT &&
 		g_Serv.m_iFreezeRestartTime )

--- a/GraySvr/graysvr.h
+++ b/GraySvr/graysvr.h
@@ -152,6 +152,7 @@ extern int FindStrWord( const TCHAR * pTextSearch, const TCHAR * pszKeyWord );
 extern struct CLog : public CFileText, public CEventLog
 {
 	// subject matter. (severity level is first 4 bits, LOGL_EVENT)
+#define LOGM_STYLE_NOCATEGORY   0x0010  // suppress category badges for styled console output.
 #define LOGM_ACCOUNTS		0x0080
 #define LOGM_INIT			0x0100	// start up messages.
 #define LOGM_SAVE			0x0200	// world save status.


### PR DESCRIPTION
## Summary
- add a log style flag so the startup banner prints without INIT category tags while keeping the same framing
- replace the percent-based progress indicator with a rotating clock hand animation for smoother console feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e196cef290832798cc781b171e0e68